### PR TITLE
Adding setup for Werkzeug profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ env
 
 .env
 config.py
+prof/

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
+import os
 from dash import Dash
 import dash_mantine_components as dmc
+from werkzeug.middleware.profiler import ProfilerMiddleware
 from components.control_bar import layout as control_bar_layout
 from components.image_viewer import layout as image_viewer_layout
 from callbacks.image_viewer import *
@@ -20,5 +22,16 @@ app.layout = dmc.MantineProvider(
     ],
 )
 
+PROF_DIR = "prof"
+
 if __name__ == "__main__":
+    if os.getenv("PROFILER", None):
+        app.server.config["PROFILE"] = True
+        app.server.wsgi_app = ProfilerMiddleware(
+            app.server.wsgi_app,
+            sort_by=["cumtime"],
+            restrictions=[50],
+            stream=None,
+            profile_dir=PROF_DIR,
+        )
     app.run_server(debug=True)

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -37,7 +37,10 @@ def render_image(
         dragmode="pan",
         height=620,
         width=620,
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
     )
+    fig.update_traces(hovertemplate=None, hoverinfo="skip")
 
     # set the default annotation style
     hex_color = dmc.theme.DEFAULT_COLORS[annotation_color][7]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 black==22.10.0
 flake8==6.0.0
+snakeviz

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -4,9 +4,11 @@ from urllib.parse import urlparse
 
 from tiled.client import from_uri
 from tiled.client.cache import Cache
+from tiled.client import show_logs
 from dotenv import load_dotenv
 
 load_dotenv()
+show_logs()
 
 TILED_URI = os.getenv("TILED_URI")
 API_KEY = os.getenv("API_KEY")


### PR DESCRIPTION
These are temporary changes to set up a profiler for the Python code. See this blog post for more detailed instructions on running the profiler and interpreting the results: https://community.plotly.com/t/performance-profiling-dash-apps-with-werkzeug/65199 -- I really recommend using `snakeviz` as well to interpret results!

I have some WIP notes on profiling results here: https://docs.google.com/presentation/d/1c5_bJ8EUX5w2VCUFq0TEa3KepsdVsMPIboKt4ThIDO4/edit#slide=id.g28d4c0551f8_0_9