### PR TITLE
Cross slice annotation saving

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -7,8 +7,8 @@ from dash import (
     ALL,
     ctx,
     clientside_callback,
-    no_update,
 )
+from dash.exceptions import PreventUpdate
 import dash_mantine_components as dmc
 import json
 from utils.data_utils import convert_hex_to_rgba, data
@@ -26,10 +26,15 @@ from utils.data_utils import convert_hex_to_rgba, data
     Input("circle", "n_clicks"),
     Input("rectangle", "n_clicks"),
     Input("drawing-off", "n_clicks"),
+    State("annotation-store", "data"),
     prevent_initial_call=True,
 )
-def annotation_mode(open, closed, circle, rect, off_mode):
+def annotation_mode(open, closed, circle, rect, off_mode, annotation_store):
     """This callback determines which drawing mode the graph is in"""
+    if "visible" in annotation_store:
+        if not annotation_store["visible"]:
+            raise PreventUpdate
+
     patched_figure = Patch()
     triggered = ctx.triggered_id
     open_style = {"border": "1px solid"}
@@ -37,6 +42,7 @@ def annotation_mode(open, closed, circle, rect, off_mode):
     circle_style = {"border": "1px solid"}
     rect_style = {"border": "1px solid"}
     pan_style = {"border": "1px solid"}
+
     if triggered == "open-freeform" and open > 0:
         patched_figure["layout"]["dragmode"] = "drawopenpath"
         open_style = {"border": "3px solid black"}
@@ -90,7 +96,7 @@ def annotation_color(color_value):
 
 
 @callback(
-    Output("annotation-store", "data"),
+    Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer", "figure", allow_duplicate=True),
     Input("view-annotations", "checked"),
     State("annotation-store", "data"),
@@ -98,25 +104,28 @@ def annotation_color(color_value):
     State("image-selection-slider", "value"),
     prevent_initial_call=True,
 )
-def annotation_visibility(checked, store, figure, image_idx):
+def annotation_visibility(checked, annotation_store, figure, image_idx):
     """
     This callback is responsible for toggling the visibility of the annotation layer.
     It also saves the annotation data to the store when the layer is hidden, and then loads it back in when the layer is shown again.
     """
-    image_idx = str(image_idx)
-
+    image_idx = str(image_idx - 1)
     patched_figure = Patch()
     if checked:
-        store["visible"] = True
-        patched_figure["layout"]["shapes"] = store[image_idx]
+        annotation_store["visible"] = True
+        patched_figure["layout"]["dragmode"] = True
+        if str(image_idx) in annotation_store:
+            patched_figure["layout"]["shapes"] = annotation_store[image_idx]
     else:
-        annotation_data = (
+        new_annotation_data = (
             [] if "shapes" not in figure["layout"] else figure["layout"]["shapes"]
         )
-        store[image_idx] = annotation_data
+        annotation_store["visible"] = False
+        patched_figure["layout"]["dragmode"] = False
+        annotation_store[image_idx] = new_annotation_data
         patched_figure["layout"]["shapes"] = []
 
-    return store, patched_figure
+    return annotation_store, patched_figure
 
 
 clientside_callback(

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -13,12 +13,14 @@ from utils.data_utils import convert_hex_to_rgba, data
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
     State("annotation-class-selection", "className"),
+    State("annotation-store", "data"),
 )
 def render_image(
     image_idx,
     project_name,
     annotation_width,
     annotation_color,
+    annotation_data,
 ):
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
@@ -42,11 +44,42 @@ def render_image(
     hex_color = dmc.theme.DEFAULT_COLORS[annotation_color][7]
     fig.update_layout(
         newshape=dict(
-            line=dict(color=annotation_color, width=annotation_width),
+            line=dict(
+                color=convert_hex_to_rgba(hex_color, 0.3), width=annotation_width
+            ),
             fillcolor=convert_hex_to_rgba(hex_color, 0.3),
         )
     )
+
+    if annotation_data:
+        if "visible" in annotation_data:
+            print("visible" in annotation_data, not annotation_data["visible"])
+            if not annotation_data["visible"]:
+                fig["layout"]["shapes"] = []
+                fig["layout"]["dragmode"] = False
+                return fig
+        if str(image_idx) in annotation_data:
+            fig["layout"]["shapes"] = annotation_data[str(image_idx)]
+
     return fig
+
+
+@callback(
+    Output("annotation-store", "data", allow_duplicate=True),
+    Input("image-viewer", "relayoutData"),
+    State("image-selection-slider", "value"),
+    State("annotation-store", "data"),
+    prevent_initial_call=True,
+)
+def locally_store_annotations(relayout_data, img_idx, annotation_data):
+    """
+    Upon finishing relayout event (drawing, but it also includes panning, zooming),
+    this function takes the annotation shapes, and stores it in the dcc.Store, which is then used elsewhere
+    to preserve drawn annotations, or to save them.
+    """
+    if "shapes" in relayout_data:
+        annotation_data[str(img_idx - 1)] = relayout_data["shapes"]
+    return annotation_data
 
 
 @callback(
@@ -54,12 +87,14 @@ def render_image(
     Output("image-selection-slider", "max"),
     Output("image-selection-slider", "value"),
     Output("image-selection-slider", "disabled"),
+    Output("annotation-store", "data"),
     Input("project-name-src", "value"),
 )
 def update_slider_values(project_name):
     """
     When the data source is loaded, this callback will set the slider values and chain call
         "update_selection_and_image" callback which will update image and slider selection component
+    It also resets "annotation-store" data to {} so that existing annotations don't carry over to the new project.
 
     ## todo - change Input("project-name-src", "data") to value when image-src will contain buckets of data and not just one image
     ## todo - eg, when a different image source is selected, update slider values which is then used to select image within that source
@@ -71,11 +106,13 @@ def update_slider_values(project_name):
     min_slider_value = 0 if disable_slider else 1
     max_slider_value = 0 if disable_slider else len(tiff_file)
     slider_value = 0 if disable_slider else 1
+    annotation_store = {}
     return (
         min_slider_value,
         max_slider_value,
         slider_value,
         disable_slider,
+        annotation_store,
     )
 
 

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -244,7 +244,10 @@ def layout():
                     ),
                 ],
             ),
-            dcc.Store(id="annotation-store", data={}),
+            dcc.Store(
+                id="annotation-store",
+                data={"dragmode": "drawopenpath", "visible": True, "annotations": {}},
+            ),
             dcc.Store(id="project-data"),
             html.Div(id="dummy-output"),
         ],


### PR DESCRIPTION
This PR adds 

- saving annotations across image slices
- saves visibility of annotations across slices
- saves dragmode (drawing) across slices
- disables dragmode (drawing) if the visibility of annotations is set to hidden

addresses #29 and it also fixes #19