### PR TITLE
🚸 preserve zoom and pan on image change

### DIFF
--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -1,4 +1,4 @@
-from dash import Input, Output, State, callback, ctx
+from dash import Input, Output, State, callback, ctx, Patch
 import dash_mantine_components as dmc
 from tifffile import imread
 import plotly.express as px
@@ -8,11 +8,13 @@ from utils.data_utils import convert_hex_to_rgba, data
 
 @callback(
     Output("image-viewer", "figure"),
+    Output("annotation-store", "data", allow_duplicate=True),
     Input("image-selection-slider", "value"),
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
     State("annotation-class-selection", "className"),
     State("annotation-store", "data"),
+    prevent_initial_call=True,
 )
 def render_image(
     image_idx,
@@ -60,7 +62,15 @@ def render_image(
         if str(image_idx) in annotation_store["annotations"]:
             fig["layout"]["shapes"] = annotation_store["annotations"][str(image_idx)]
 
-    return fig
+        view = annotation_store["view"]
+        if "xaxis_range_0" in view and annotation_store["image_size"] == tf.size:
+            fig.update_layout(
+                xaxis=dict(range=[view["xaxis_range_0"], view["xaxis_range_1"]]),
+                yaxis=dict(range=[view["yaxis_range_0"], view["yaxis_range_1"]]),
+            )
+    patched_annotation_store = Patch()
+    patched_annotation_store["image_size"] = tf.size
+    return fig, patched_annotation_store
 
 
 @callback(
@@ -78,6 +88,13 @@ def locally_store_annotations(relayout_data, img_idx, annotation_store):
     """
     if "shapes" in relayout_data:
         annotation_store["annotations"][str(img_idx - 1)] = relayout_data["shapes"]
+
+    if "xaxis.range[0]" in relayout_data:
+        annotation_store["view"]["xaxis_range_0"] = relayout_data["xaxis.range[0]"]
+        annotation_store["view"]["xaxis_range_1"] = relayout_data["xaxis.range[1]"]
+        annotation_store["view"]["yaxis_range_0"] = relayout_data["yaxis.range[0]"]
+        annotation_store["view"]["yaxis_range_1"] = relayout_data["yaxis.range[1]"]
+
     return annotation_store
 
 

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -246,7 +246,13 @@ def layout():
             ),
             dcc.Store(
                 id="annotation-store",
-                data={"dragmode": "drawopenpath", "visible": True, "annotations": {}},
+                data={
+                    "dragmode": "drawopenpath",
+                    "visible": True,
+                    "annotations": {},
+                    "view": {},
+                    "image_size": [],
+                },
             ),
             dcc.Store(id="project-data"),
             html.Div(id="dummy-output"),


### PR DESCRIPTION
when image is changed, (and its size is different) zoom and pan will be preserved.

This will most likely need to be revisited because when compressed images are being sent, their sizes differ depending on the zoom, and thus we most likely won't be able to determine whether the image size is the same?
Also we will need to upgrade this with the same system we add where we ask for specific part of the image.

The image size needs to be there because if image1 is 2500x2500 and image2 is 200x200, if we zoom on image1 and then switch to image 2, it would most likely result in a white screen since we would be panned out of 200x200 bounds