### PR TITLE
Update annotation UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from dash import Dash
+from dash import Dash, dcc
 import dash_mantine_components as dmc
 from components.control_bar import layout as control_bar_layout
 from components.image_viewer import layout as image_viewer_layout
@@ -16,7 +16,8 @@ app.layout = dmc.MantineProvider(
                 control_bar_layout(),
                 image_viewer_layout(),
             ],
-        )
+        ),
+        dcc.Store(id="current-ann-mode"),
     ],
 )
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,9 +1,4 @@
-/* These css classes highlight the selected annotation color (class)  */
-
-.red>.red-icon,
-.grape>.grape-icon,
-.violet>.violet-icon,
-.blue>.blue-icon,
-.yellow>.yellow-icon {
-    border: 3px solid black;
+.flex-row {
+    display: flex;
+    flex-direction: row;
 }

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -20,55 +20,65 @@ from utils.data_utils import convert_hex_to_rgba, data
     Output("closed-freeform", "style"),
     Output("circle", "style"),
     Output("rectangle", "style"),
+    Output("eraser", "style"),
     Output("drawing-off", "style"),
     Output("annotation-store", "data", allow_duplicate=True),
     Input("open-freeform", "n_clicks"),
     Input("closed-freeform", "n_clicks"),
     Input("circle", "n_clicks"),
     Input("rectangle", "n_clicks"),
+    Input("eraser", "n_clicks"),
     Input("drawing-off", "n_clicks"),
     State("annotation-store", "data"),
     prevent_initial_call=True,
 )
-def annotation_mode(open, closed, circle, rect, off_mode, annotation_store):
+def annotation_mode(open, closed, circle, rect, eraser, off_mode, annotation_store):
     """This callback determines which drawing mode the graph is in"""
     if not annotation_store["visible"]:
         raise PreventUpdate
 
     patched_figure = Patch()
     triggered = ctx.triggered_id
-    open_style = {"border": "1px solid"}
-    close_style = {"border": "1px solid"}
-    circle_style = {"border": "1px solid"}
-    rect_style = {"border": "1px solid"}
-    pan_style = {"border": "1px solid"}
+    active = {"border": "3px solid black"}
+    inactive = {"border": "1px solid"}
+    open_style = inactive
+    close_style = inactive
+    circle_style = inactive
+    rect_style = inactive
+    pan_style = inactive
+    eraser_style = inactive
 
     if triggered == "open-freeform" and open > 0:
         patched_figure["layout"]["dragmode"] = "drawopenpath"
         annotation_store["dragmode"] = "drawopenpath"
-        open_style = {"border": "3px solid black"}
+        open_style = active
     if triggered == "closed-freeform" and closed > 0:
         patched_figure["layout"]["dragmode"] = "drawclosedpath"
         annotation_store["dragmode"] = "drawclosedpath"
-        close_style = {"border": "3px solid black"}
+        close_style = active
     if triggered == "circle" and circle > 0:
         patched_figure["layout"]["dragmode"] = "drawcircle"
         annotation_store["dragmode"] = "drawcircle"
-        circle_style = {"border": "3px solid black"}
+        circle_style = active
     if triggered == "rectangle" and rect > 0:
         patched_figure["layout"]["dragmode"] = "drawrect"
         annotation_store["dragmode"] = "drawrect"
-        rect_style = {"border": "3px solid black"}
+        rect_style = active
+    if triggered == "eraser" and eraser > 0:
+        patched_figure["layout"]["dragmode"] = "select"
+        annotation_store["dragmode"] = "select"
+        eraser_style = active
     if triggered == "drawing-off" and off_mode > 0:
         patched_figure["layout"]["dragmode"] = "pan"
         annotation_store["dragmode"] = "pan"
-        pan_style = {"border": "3px solid black"}
+        pan_style = active
     return (
         patched_figure,
         open_style,
         close_style,
         circle_style,
         rect_style,
+        eraser_style,
         pan_style,
         annotation_store,
     )
@@ -109,37 +119,54 @@ def annotation_color(color_value):
 
 
 @callback(
+    Output("delete-all-warning", "opened"),
+    Input("delete-all", "n_clicks"),
+    Input("modal-cancel-button", "n_clicks"),
+    Input("modal-delete-button", "n_clicks"),
+    State("delete-all-warning", "opened"),
+    prevent_initial_call=True,
+)
+def open_warning_modal(delete, cancel, delete_4_real, opened):
+    return not opened
+
+
+@callback(
     Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer", "figure", allow_duplicate=True),
     Input("view-annotations", "checked"),
+    Input("modal-delete-button", "n_clicks"),
     State("annotation-store", "data"),
     State("image-viewer", "figure"),
     State("image-selection-slider", "value"),
     prevent_initial_call=True,
 )
-def annotation_visibility(checked, annotation_store, figure, image_idx):
+def annotation_visibility(checked, delete_all, annotation_store, figure, image_idx):
     """
     This callback is responsible for toggling the visibility of the annotation layer.
     It also saves the annotation data to the store when the layer is hidden, and then loads it back in when the layer is shown again.
     """
     image_idx = str(image_idx - 1)
     patched_figure = Patch()
-    if checked:
-        annotation_store["visible"] = True
-        patched_figure["layout"]["visible"] = True
-        if str(image_idx) in annotation_store["annotations"]:
-            patched_figure["layout"]["shapes"] = annotation_store["annotations"][
-                image_idx
-            ]
-        patched_figure["layout"]["dragmode"] = annotation_store["dragmode"]
-    else:
-        new_annotation_data = (
-            [] if "shapes" not in figure["layout"] else figure["layout"]["shapes"]
-        )
-        annotation_store["visible"] = False
-        patched_figure["layout"]["dragmode"] = False
-        annotation_store["annotations"][image_idx] = new_annotation_data
+    if ctx.triggered_id == "modal-delete-button":
+        annotation_store["annotations"][image_idx] = []
         patched_figure["layout"]["shapes"] = []
+    else:
+        if checked:
+            annotation_store["visible"] = True
+            patched_figure["layout"]["visible"] = True
+            if str(image_idx) in annotation_store["annotations"]:
+                patched_figure["layout"]["shapes"] = annotation_store["annotations"][
+                    image_idx
+                ]
+            patched_figure["layout"]["dragmode"] = annotation_store["dragmode"]
+        else:
+            new_annotation_data = (
+                [] if "shapes" not in figure["layout"] else figure["layout"]["shapes"]
+            )
+            annotation_store["visible"] = False
+            patched_figure["layout"]["dragmode"] = False
+            annotation_store["annotations"][image_idx] = new_annotation_data
+            patched_figure["layout"]["shapes"] = []
 
     return annotation_store, patched_figure
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -3,7 +3,7 @@ import dash_mantine_components as dmc
 from tifffile import imread
 import plotly.express as px
 import numpy as np
-from utils.data_utils import convert_hex_to_rgba, data
+from utils.data_utils import data
 
 
 @callback(
@@ -11,14 +11,14 @@ from utils.data_utils import convert_hex_to_rgba, data
     Input("image-selection-slider", "value"),
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
-    State("annotation-class-selection", "className"),
+    State("annotation-class-selection", "children"),
     State("annotation-store", "data"),
 )
 def render_image(
     image_idx,
     project_name,
     annotation_width,
-    annotation_color,
+    annotation_colors,
     annotation_store,
 ):
     if image_idx:
@@ -40,13 +40,13 @@ def render_image(
     fig.update_traces(hovertemplate=None, hoverinfo="skip")
 
     # set the default annotation style
-    hex_color = dmc.theme.DEFAULT_COLORS[annotation_color][7]
+    for color_opt in annotation_colors:
+        if color_opt["props"]["style"]["border"] != "1px solid":
+            color = color_opt["props"]["style"]["background-color"]
     fig.update_layout(
         newshape=dict(
-            line=dict(
-                color=convert_hex_to_rgba(hex_color, 0.3), width=annotation_width
-            ),
-            fillcolor=convert_hex_to_rgba(hex_color, 0.3),
+            line=dict(color=color, width=annotation_width),
+            fillcolor=color,
         )
     )
     if annotation_store:

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -135,7 +135,8 @@ def layout():
                                             children=DashIconify(icon="mdi:draw"),
                                             style={"border": "3px solid black"},
                                         ),
-                                        label="Open Freeform",
+                                        label="Open Freeform: draw any open shape",
+                                        multiline=True,
                                     ),
                                     dmc.Tooltip(
                                         dmc.ActionIcon(
@@ -146,7 +147,8 @@ def layout():
                                                 icon="fluent:draw-shape-20-regular"
                                             ),
                                         ),
-                                        label="Closed Freeform",
+                                        label="Closed Freeform: draw a shape that will auto-complete",
+                                        multiline=True,
                                     ),
                                     dmc.Tooltip(
                                         dmc.ActionIcon(
@@ -157,7 +159,8 @@ def layout():
                                                 icon="gg:shape-circle"
                                             ),
                                         ),
-                                        label="Circle",
+                                        label="Circle: create a filled circle",
+                                        multiline=True,
                                     ),
                                     dmc.Tooltip(
                                         dmc.ActionIcon(
@@ -168,7 +171,31 @@ def layout():
                                                 icon="gg:shape-square"
                                             ),
                                         ),
-                                        label="Rectangle",
+                                        label="Rectangle: create a filled rectangle",
+                                        multiline=True,
+                                    ),
+                                    html.Div(id="test"),
+                                    dmc.Tooltip(
+                                        dmc.ActionIcon(
+                                            id="eraser",
+                                            variant="outline",
+                                            color="gray",
+                                            children=DashIconify(icon="ph:eraser"),
+                                        ),
+                                        label="Eraser: click on shapes to delete them",
+                                        multiline=True,
+                                    ),
+                                    dmc.Tooltip(
+                                        dmc.ActionIcon(
+                                            id="delete-all",
+                                            variant="outline",
+                                            color="gray",
+                                            children=DashIconify(
+                                                icon="octicon:trash-24"
+                                            ),
+                                        ),
+                                        label="Clear All Annotations",
+                                        multiline=True,
                                     ),
                                     dmc.Tooltip(
                                         dmc.ActionIcon(
@@ -177,7 +204,32 @@ def layout():
                                             color="gray",
                                             children=DashIconify(icon="el:off"),
                                         ),
-                                        label="Stop Drawing",
+                                        label="Stop Drawing: pan, zoom, select annotations and edit them using the nodes",
+                                        multiline=True,
+                                    ),
+                                ],
+                            ),
+                            dmc.Modal(
+                                title="Warning",
+                                id="delete-all-warning",
+                                children=[
+                                    dmc.Text(
+                                        "This action will permanently clear all annotations on this image frame. Are you sure you want to proceed?"
+                                    ),
+                                    dmc.Space(h=20),
+                                    dmc.Group(
+                                        [
+                                            dmc.Button(
+                                                "Cancel", id="modal-cancel-button"
+                                            ),
+                                            dmc.Button(
+                                                "Continue",
+                                                color="red",
+                                                variant="outline",
+                                                id="modal-delete-button",
+                                            ),
+                                        ],
+                                        position="right",
                                     ),
                                 ],
                             ),

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -174,7 +174,6 @@ def layout():
                                         label="Rectangle: create a filled rectangle",
                                         multiline=True,
                                     ),
-                                    html.Div(id="test"),
                                     dmc.Tooltip(
                                         dmc.ActionIcon(
                                             id="eraser",
@@ -250,30 +249,93 @@ def layout():
                                 spacing="xs",
                                 grow=True,
                                 id="annotation-class-selection",
-                                className=DEFAULT_ANNOTATION_CLASS,
                                 children=[
                                     dmc.ActionIcon(
-                                        children=(i + 1),
-                                        color=color,
-                                        variant="filled",
-                                        className=f"{color}-icon",
-                                        id={"type": "annotation-color", "index": color},
+                                        id={
+                                            "type": "annotation-color",
+                                            "index": "rgb(249,82,82)",
+                                        },
                                         w=30,
-                                    )
-                                    for i, color in enumerate(
+                                        variant="filled",
+                                        style={
+                                            "background-color": "rgb(249,82,82)",
+                                            "border": "3px solid black",
+                                        },
+                                        children="1",
+                                    ),
+                                ],
+                            ),
+                            dmc.Space(h=5),
+                            html.Div(
+                                [
+                                    dmc.Button(
+                                        id="generate-annotation-class",
+                                        children="Generate Class",
+                                        variant="outline",
+                                        leftIcon=DashIconify(icon="ic:baseline-plus"),
+                                    ),
+                                    dmc.Button(
+                                        id="delete-annotation-class",
+                                        children="Delete Class",
+                                        variant="outline",
+                                        style={"margin-left": "auto"},
+                                        leftIcon=DashIconify(icon="octicon:trash-24"),
+                                    ),
+                                ],
+                                className="flex-row",
+                            ),
+                            dmc.Modal(
+                                id="generate-annotation-class-modal",
+                                title="Generate a Custom Annotation Class",
+                                children=[
+                                    dmc.Center(
+                                        dmc.ColorPicker(
+                                            id="annotation-class-colorpicker",
+                                            format="rgb",
+                                        ),
+                                    ),
+                                    dmc.Space(h=10),
+                                    dmc.Center(
+                                        dmc.TextInput(
+                                            id="annotation-class-label",
+                                            placeholder="Annotation Class Label",
+                                        ),
+                                    ),
+                                    dmc.Space(h=10),
+                                    dmc.Center(
+                                        dmc.Button(
+                                            id="create-annotation-class",
+                                            children="Create Annotation Class",
+                                            variant="light",
+                                        ),
+                                    ),
+                                ],
+                            ),
+                            dmc.Modal(
+                                id="delete-annotation-class-modal",
+                                title="Delete Custom Annotation Class(es)",
+                                children=[
+                                    dmc.Text("Select all generated classes to remove:"),
+                                    dmc.Group(
+                                        spacing="xs",
+                                        grow=True,
+                                        id="current-annotation-classes",
+                                    ),
+                                    dmc.Space(h=10),
+                                    dmc.Center(
                                         [
-                                            # "gray",
-                                            "red",
-                                            # "pink",
-                                            "grape",
-                                            "violet",
-                                            # "indigo",
-                                            "blue",
-                                            # "lime",
-                                            "yellow",
-                                            # "orange",
+                                            dmc.Button(
+                                                id="remove-annotation-class",
+                                                children="Delete Selected Class(es)",
+                                                variant="light",
+                                            ),
                                         ]
-                                    )
+                                    ),
+                                    dmc.Text(
+                                        "There must be at least one annotation class!",
+                                        color="red",
+                                        id="at-least-one",
+                                    ),
                                 ],
                             ),
                             dmc.Space(h=20),

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -71,7 +71,3 @@ else:
 
 def get_data_project_names():
     return list(data)
-
-
-def convert_hex_to_rgba(hex, alpha=0.3):
-    return f"rgba{tuple(int(hex[i:i+2], 16) for i in (1, 3, 5)) + (alpha,)}"


### PR DESCRIPTION
Adds a garbage button to delete all annotations on the currently viewed frame, an eraser button (which does not work yet, waiting on Mojtaba to fix plotly bug), custom annotation class generator/deleter so that a user can choose a custom colour and label for an annotation class and then use them to annotate the graph. 

I'm leaving the hover bar in the graph until we get the eraser mode working