### PR TITLE
✨ Disable controls while loading

### DIFF
--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -110,6 +110,75 @@ def locally_store_annotations(relayout_data, img_idx, annotation_store):
     return annotation_store
 
 
+clientside_callback(
+    """
+    function DisableControlsDuringLoading(project_source_trigger, slider_trigger) {
+    console.log(window.dash_clientside.callback_context.triggered)
+        return Array(17).fill(true)
+    }
+    """,
+    Output("figure-brightness", "disabled"),
+    Output("figure-contrast", "disabled"),
+    Output("filters-reset", "disabled"),
+    Output("view-annotations", "disabled"),
+    Output("open-freeform", "disabled"),
+    Output("closed-freeform", "disabled"),
+    Output("circle", "disabled"),
+    Output("rectangle", "disabled"),
+    Output("drawing-off", "disabled"),
+    Output("paintbrush-width", "disabled"),
+    Output("annotation-class-selection", "disabled"),
+    Output("annotation-class-selection", "disabled", "disabled"),
+    Output({"type": "annotation-color", "index": "red"}, "disabled"),
+    Output({"type": "annotation-color", "index": "grape"}, "disabled"),
+    Output({"type": "annotation-color", "index": "violet"}, "disabled"),
+    Output({"type": "annotation-color", "index": "blue"}, "disabled"),
+    Output({"type": "annotation-color", "index": "yellow"}, "disabled"),
+    Input("project-name-src", "value"),
+    Input("image-selection-slider", "value"),
+    prevent_initial_call="initial_duplicate",
+)
+clientside_callback(
+    """
+    function EnableControlsAfterLoading(project_source_trigger) {
+        return Array(17).fill(false)
+    }
+    """,
+    Output("figure-brightness", "disabled", allow_duplicate=True),
+    Output("figure-contrast", "disabled", allow_duplicate=True),
+    Output("filters-reset", "disabled", allow_duplicate=True),
+    Output("view-annotations", "disabled", allow_duplicate=True),
+    Output("open-freeform", "disabled", allow_duplicate=True),
+    Output("closed-freeform", "disabled", allow_duplicate=True),
+    Output("circle", "disabled", allow_duplicate=True),
+    Output("rectangle", "disabled", allow_duplicate=True),
+    Output("drawing-off", "disabled", allow_duplicate=True),
+    Output("paintbrush-width", "disabled", allow_duplicate=True),
+    Output("annotation-class-selection", "disabled", allow_duplicate=True),
+    Output(
+        {"type": "annotation-color", "index": "red"}, "disabled", allow_duplicate=True
+    ),
+    Output(
+        {"type": "annotation-color", "index": "grape"}, "disabled", allow_duplicate=True
+    ),
+    Output(
+        {"type": "annotation-color", "index": "violet"},
+        "disabled",
+        allow_duplicate=True,
+    ),
+    Output(
+        {"type": "annotation-color", "index": "blue"}, "disabled", allow_duplicate=True
+    ),
+    Output(
+        {"type": "annotation-color", "index": "yellow"},
+        "disabled",
+        allow_duplicate=True,
+    ),
+    Input("image-viewer", "figure"),
+    prevent_initial_call=True,
+)
+
+
 @callback(
     Output("image-selection-slider", "min"),
     Output("image-selection-slider", "max"),

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -71,6 +71,7 @@ def layout():
                                     step=1,
                                     color="gray",
                                     size="sm",
+                                    disabled=True,
                                 ),
                                 dmc.Space(h=5),
                                 dmc.Text("Contrast", size="sm"),
@@ -82,6 +83,7 @@ def layout():
                                     step=1,
                                     color="gray",
                                     size="sm",
+                                    disabled=True,
                                 ),
                                 dmc.Space(h=10),
                                 dmc.ActionIcon(
@@ -101,6 +103,7 @@ def layout():
                                     mb=10,
                                     ml="auto",
                                     style={"margin": "auto"},
+                                    disabled=True,
                                 ),
                             ]
                         ),
@@ -119,6 +122,7 @@ def layout():
                                     label="View annotation layer",
                                     checked=True,
                                     styles={"trackLabel": {"cursor": "pointer"}},
+                                    disabled=True,
                                 )
                             ),
                             dmc.Space(h=20),
@@ -134,6 +138,7 @@ def layout():
                                             color="gray",
                                             children=DashIconify(icon="mdi:draw"),
                                             style={"border": "3px solid black"},
+                                            disabled=True,
                                         ),
                                         label="Open Freeform",
                                     ),
@@ -145,6 +150,7 @@ def layout():
                                             children=DashIconify(
                                                 icon="fluent:draw-shape-20-regular"
                                             ),
+                                            disabled=True,
                                         ),
                                         label="Closed Freeform",
                                     ),
@@ -156,6 +162,7 @@ def layout():
                                             children=DashIconify(
                                                 icon="gg:shape-circle"
                                             ),
+                                            disabled=True,
                                         ),
                                         label="Circle",
                                     ),
@@ -167,6 +174,7 @@ def layout():
                                             children=DashIconify(
                                                 icon="gg:shape-square"
                                             ),
+                                            disabled=True,
                                         ),
                                         label="Rectangle",
                                     ),
@@ -176,6 +184,7 @@ def layout():
                                             variant="outline",
                                             color="gray",
                                             children=DashIconify(icon="el:off"),
+                                            disabled=True,
                                         ),
                                         label="Stop Drawing",
                                     ),
@@ -191,6 +200,7 @@ def layout():
                                 step=1,
                                 color="gray",
                                 size="sm",
+                                disabled=True,
                             ),
                             dmc.Space(h=20),
                             dmc.Text("Annotation class", size="sm"),
@@ -207,6 +217,7 @@ def layout():
                                         className=f"{color}-icon",
                                         id={"type": "annotation-color", "index": color},
                                         w=30,
+                                        disabled=True,
                                     )
                                     for i, color in enumerate(
                                         [


### PR DESCRIPTION
Disables controls on
- initial app load
- project change
- slice change

Something to think about:
if the UX is a problem, we remove, let controls be usable while images are loading, and "cache" the changed controls.
Then every time a figure finishes plotting, look at the cache, and see if anything has changed since the plot creation event, if yes patch it => no constant enabling/disabling of controls, and having to wait for the user to be able to interact with them.
