### PR TITLE
🐛 disable controls using loadingOverlay

### DIFF
--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -11,9 +11,9 @@ from utils.data_utils import convert_hex_to_rgba, data
     Output("image-viewer", "figure"),
     Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer-loading", "zIndex", allow_duplicate=True),
-    Output("data-selection-controls", "children"),
-    Output("image-transformation-controls", "children"),
-    Output("annotations-controls", "children"),
+    Output("data-selection-controls", "children", allow_duplicate=True),
+    Output("image-transformation-controls", "children", allow_duplicate=True),
+    Output("annotations-controls", "children", allow_duplicate=True),
     Input("image-selection-slider", "value"),
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
@@ -75,8 +75,8 @@ def render_image(
     patched_annotation_store["image_size"] = tf.size
     fig_loading_overlay = -1
 
-    # No update is needed for the 'children' of the control components since we just want to trigger the loading
-    # overlay with this callback
+    # No update is needed for the 'children' of the control components
+    # since we just want to trigger the loading overlay with this callback
     return (
         fig,
         patched_annotation_store,
@@ -129,6 +129,9 @@ def locally_store_annotations(relayout_data, img_idx, annotation_store):
     Output("image-selection-slider", "value"),
     Output("image-selection-slider", "disabled"),
     Output("annotation-store", "data"),
+    Output("data-selection-controls", "children"),
+    Output("image-transformation-controls", "children"),
+    Output("annotations-controls", "children"),
     Input("project-name-src", "value"),
     State("annotation-store", "data"),
 )
@@ -155,6 +158,11 @@ def update_slider_values(project_name, annotation_store):
         slider_value,
         disable_slider,
         annotation_store,
+        # No update is needed for the 'children' of the control components
+        # since we just want to trigger the loading overlay with this callback
+        dash.no_update,
+        dash.no_update,
+        dash.no_update,
     )
 
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -74,10 +74,17 @@ def render_image(
     patched_annotation_store = Patch()
     patched_annotation_store["image_size"] = tf.size
     fig_loading_overlay = -1
-   
+
     # No update is needed for the 'children' of the control components since we just want to trigger the loading
     # overlay with this callback
-    return fig, patched_annotation_store, fig_loading_overlay, dash.no_update, dash.no_update, dash.no_update,
+    return (
+        fig,
+        patched_annotation_store,
+        fig_loading_overlay,
+        dash.no_update,
+        dash.no_update,
+        dash.no_update,
+    )
 
 
 clientside_callback(

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -1,4 +1,5 @@
 from dash import Input, Output, State, callback, ctx, Patch, clientside_callback
+import dash
 import dash_mantine_components as dmc
 from tifffile import imread
 import plotly.express as px
@@ -10,6 +11,9 @@ from utils.data_utils import convert_hex_to_rgba, data
     Output("image-viewer", "figure"),
     Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer-loading", "zIndex", allow_duplicate=True),
+    Output("data-selection-controls", "children"),
+    Output("image-transformation-controls", "children"),
+    Output("annotations-controls", "children"),
     Input("image-selection-slider", "value"),
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
@@ -70,8 +74,10 @@ def render_image(
     patched_annotation_store = Patch()
     patched_annotation_store["image_size"] = tf.size
     fig_loading_overlay = -1
-
-    return fig, patched_annotation_store, fig_loading_overlay
+   
+    # No update is needed for the 'children' of the control components since we just want to trigger the loading
+    # overlay with this callback
+    return fig, patched_annotation_store, fig_loading_overlay, dash.no_update, dash.no_update, dash.no_update,
 
 
 clientside_callback(

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -25,7 +25,11 @@ def _accordion_item(title, icon, value, children, id):
                     width=20,
                 ),
             ),
-            dmc.LoadingOverlay(dmc.AccordionPanel(children=children, id=id), loaderProps={"size": 0}, overlayOpacity=0.4,),
+            dmc.LoadingOverlay(
+                dmc.AccordionPanel(children=children, id=id),
+                loaderProps={"size": 0},
+                overlayOpacity=0.4,
+            ),
         ],
         value=value,
     )
@@ -45,7 +49,7 @@ def layout():
                         "Data selection",
                         "majesticons:data-line",
                         "data-select",
-                        id='data-selection-controls',
+                        id="data-selection-controls",
                         children=[
                             dmc.Text("Image"),
                             dmc.Select(
@@ -61,7 +65,7 @@ def layout():
                         "Image transformations",
                         "fluent-mdl2:image-pixel",
                         "image-transformations",
-                        id='image-transformation-controls',
+                        id="image-transformation-controls",
                         children=html.Div(
                             [
                                 dmc.Text("Brightness", size="sm"),
@@ -111,7 +115,7 @@ def layout():
                         "Annotation tools",
                         "mdi:paintbrush-outline",
                         "annotations",
-                        id='annotations-controls',
+                        id="annotations-controls",
                         children=[
                             dmc.Center(
                                 dmc.Switch(

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -14,7 +14,7 @@ COMPONENT_STYLE = {
 DEFAULT_ANNOTATION_CLASS = "red"
 
 
-def _accordion_item(title, icon, value, children):
+def _accordion_item(title, icon, value, children, id):
     return dmc.AccordionItem(
         [
             dmc.AccordionControl(
@@ -25,7 +25,7 @@ def _accordion_item(title, icon, value, children):
                     width=20,
                 ),
             ),
-            dmc.AccordionPanel(children),
+            dmc.LoadingOverlay(dmc.AccordionPanel(children=children, id=id), loaderProps={"size": 0}),
         ],
         value=value,
     )
@@ -45,6 +45,7 @@ def layout():
                         "Data selection",
                         "majesticons:data-line",
                         "data-select",
+                        id='data-selection-controls',
                         children=[
                             dmc.Text("Image"),
                             dmc.Select(
@@ -60,6 +61,7 @@ def layout():
                         "Image transformations",
                         "fluent-mdl2:image-pixel",
                         "image-transformations",
+                        id='image-transformation-controls',
                         children=html.Div(
                             [
                                 dmc.Text("Brightness", size="sm"),
@@ -109,6 +111,7 @@ def layout():
                         "Annotation tools",
                         "mdi:paintbrush-outline",
                         "annotations",
+                        id='annotations-controls',
                         children=[
                             dmc.Center(
                                 dmc.Switch(

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -25,7 +25,7 @@ def _accordion_item(title, icon, value, children, id):
                     width=20,
                 ),
             ),
-            dmc.LoadingOverlay(dmc.AccordionPanel(children=children, id=id), loaderProps={"size": 0}),
+            dmc.LoadingOverlay(dmc.AccordionPanel(children=children, id=id), loaderProps={"size": 0}, overlayOpacity=0.4,),
         ],
         value=value,
     )


### PR DESCRIPTION
Proposing a slightly simpler approach to #51 -- addressing #41. I like this approach because it means that we don't have to update any callbacks when new controls are added into the existing sections on the sidebar. Since the loading spinner itself isn't visible it looks basically the same as if the controls are disabled. 