### PR TITLE
Enhancements to annotation class generation + prep for eraser functionality

### DIFF
--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -188,7 +188,7 @@ def layout():
                                             color="gray",
                                             children=DashIconify(icon="ph:eraser"),
                                         ),
-                                        label="Eraser: click on shapes to delete them",
+                                        label="Eraser: click on the shape to erase then click this button to delete the selected shape",
                                         multiline=True,
                                     ),
                                     dmc.Tooltip(
@@ -316,6 +316,7 @@ def layout():
                                             variant="light",
                                         ),
                                     ),
+                                    html.Div(id="bad-label-color"),
                                 ],
                             ),
                             dmc.Modal(
@@ -338,10 +339,12 @@ def layout():
                                             ),
                                         ]
                                     ),
-                                    dmc.Text(
-                                        "There must be at least one annotation class!",
-                                        color="red",
-                                        id="at-least-one",
+                                    dmc.Center(
+                                        dmc.Text(
+                                            "There must be at least one annotation class!",
+                                            color="red",
+                                            id="at-least-one",
+                                        ),
                                     ),
                                 ],
                             ),
@@ -373,6 +376,7 @@ def layout():
                     "annotations": {},
                     "view": {},
                     "image_size": [],
+                    "classes": {1: "1"},
                 },
             ),
             dcc.Store(id="project-data"),

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -13,21 +13,8 @@ COMPONENT_STYLE = {
 }
 
 FIGURE_CONFIG = {
-    "modeBarButtonsToAdd": [
-        "drawopenpath",
-        "drawclosedpath",
-        "eraseshape",
-        "drawline",
-        "drawcircle",
-        "drawrect",
-    ],
+    "displayModeBar": False,
     "scrollZoom": True,
-    "modeBarButtonsToRemove": [
-        "zoom",
-        "zoomin",
-        "zoomout",
-        "autoscale",
-    ],
 }
 
 


### PR DESCRIPTION
- Removes the hover toolbar from the graph
- Adds the callback that will enable the eraser mode when we get a new release of plotly.py package
- Adds a "classes" key to the annotation-store data which has form {"increasing int": "class label"} where "increasing int" starts at 1 and is incremented upwards for each new annotation class.
- Restricts the user such that a new class cannot be generated with a colour or label that already is in use

Closes #34 