### PR TITLE
✨ relative position viefinder

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -6,3 +6,17 @@
 .mantine-Grid-col>.mantine-1avyp1d {
     margin: auto;
 }
+
+/* make figure viewfinder transparent */
+#image-viewfinder {
+    filter: opacity(0.5);
+    -webkit-filter: opacity(0.5);
+}
+
+/* remove mouse pointer from the figure viewfinder */
+#image-viewfinder * {
+    pointer-events: none !important;
+    position: absolute;
+    top: 0;
+    right: 0;
+}

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -119,6 +119,8 @@ def update_viefinder(relayout_data, annotation_store):
         patched_fig["layout"]["shapes"][0]["y0"] = DOWNSCALED_img_max_height
         patched_fig["layout"]["shapes"][0]["x1"] = DOWNSCALED_img_max_width
         patched_fig["layout"]["shapes"][0]["y1"] = 0
+    elif "xaxis.range[0]" not in relayout_data:
+        raise dash.exceptions.PreventUpdate
     else:
         x0, y0, x1, y1 = downscale_view(
             relayout_data["xaxis.range[0]"],

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -389,7 +389,7 @@ def layout():
                     "visible": True,
                     "annotations": {},
                     "view": {},
-                    "image_size": [],
+                    "active_img_shape": [],
                     # TODO: Hard-coding default annotation class
                     "label_mapping": [
                         {

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -93,6 +93,12 @@ def layout():
                         figure=blank_fig(),
                         style={"margin": "auto", "height": "calc(-150px + 100vh)"},
                     ),
+                    dcc.Graph(
+                        id="image-viewfinder",
+                        figure=blank_fig(),
+                        config={"displayModeBar": False},
+                        style={"width": "10vh", "height": "10vh"},
+                    ),
                 ],
                 style={"display": "flex"},
             ),

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -1,10 +1,115 @@
 import plotly.graph_objects as go
+import plotly.express as px
+from skimage.transform import resize
 
 
 def blank_fig():
+    """
+    Creates a blank figure with no axes, grid, or background.
+    """
     fig = go.Figure(go.Scatter(x=[], y=[]))
     fig.update_layout(template=None)
     fig.update_xaxes(showgrid=False, showticklabels=False, zeroline=False)
     fig.update_yaxes(showgrid=False, showticklabels=False, zeroline=False)
 
+    return fig
+
+
+def downscale_view(
+    x0_original,
+    y0_original,
+    x1_original,
+    y1_original,
+    active_image_size,
+    downscaled_image_size,
+):
+    """
+    This function takes pan+zoom location in the original image and downscales it relatively to viewfinder's lower resolution.
+    params:
+        x0_original, y0_original, x1_original, y1_original: coordinates of the pan+zoom box in the original image - obtained from relayoutData
+        active_image_size: size of the original image (height, width) in pixels
+        downscaled_image_size: size of the viewfinder (height, width) in pixels
+    returns:
+        x0, y0, x1, y1: coordinates of the downscaled pan+zoom box in the viewfinder
+    """
+    max_height, max_width = downscaled_image_size
+    original_height, original_width = active_image_size
+    scaling_factor_height = original_height / max_height
+    scaling_factor_width = original_width / max_width
+    inverse_scaling_factor_height = 1.0 / scaling_factor_height
+    inverse_scaling_factor_width = 1.0 / scaling_factor_width
+
+    x0 = x0_original * inverse_scaling_factor_width
+    y0 = y0_original * inverse_scaling_factor_height
+    x1 = x1_original * inverse_scaling_factor_width
+    y1 = y1_original * inverse_scaling_factor_height
+    return x0, y0, x1, y1
+
+
+def create_viewfinder(image_data, annotation_store, downscaled_image_shape):
+    """
+    Creates a viewfinder for the image viewer. The viewfinder is a small box that shows the current view of the image
+    in the image viewer. It is used to quickly navigate to different parts of the image.
+    The image viewer is a downscaled to `downscaled_image_shape` version of the original image.
+    """
+    img_max_height, img_max_width = downscaled_image_shape
+    img_resized = resize(image_data, (img_max_height, img_max_width))
+
+    # Create the downscale image
+    fig = px.imshow(
+        img_resized,
+        binary_string=True,
+        width=img_max_height,
+        height=img_max_width,
+    )
+
+    view = annotation_store["view"]
+    if "xaxis_range_0" in view:
+        x0, y0, x1, y1 = downscale_view(
+            view["xaxis_range_0"],
+            view["yaxis_range_1"],
+            view["xaxis_range_1"],
+            view["yaxis_range_0"],
+            image_data.shape,
+            (img_max_height, img_max_width),
+        )
+    else:
+        x0 = 0
+        y0 = img_max_height
+        x1 = img_max_width
+        y1 = 0
+
+    # Create the viewfinder box
+    fig.add_shape(
+        type="rect",
+        xref="x",
+        yref="y",
+        x0=x0,
+        y0=y0,
+        x1=x1,
+        y1=y1,
+        line=dict(color="red", width=5),
+    )
+
+    # Update the layout to any remove other elements other than image and box
+    fig.update_layout(
+        xaxis=dict(
+            showline=False,
+            showticklabels=False,
+            showgrid=False,
+            zeroline=False,
+            fixedrange=True,
+        ),
+        yaxis=dict(
+            showline=False,
+            showticklabels=False,
+            showgrid=False,
+            zeroline=False,
+            fixedrange=True,
+        ),
+        title="",
+        showlegend=False,
+        margin=dict(l=0, r=0, t=0, b=0),
+        hovermode=False,
+    )
     return fig


### PR DESCRIPTION
Adds viewfinder that shows the relative position on the graph

- the viewfinder is bounded to the figure layout, if the user zooms out/pans out the boundary will still be visible
- the boundary is carried over when the user selects a new image slice
- the viewfinder is downsampled so that it doesn't bottleneck networking
- the viewfinder is being Patched to improve performance. If required, this can be changed to clientside JS code, however, right now one move causes ~400B of network traffic which is negligible