### PR TITLE
Annotation feature revamp

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -145,6 +145,8 @@ def annotation_color(color_value, current_style):
     This callback is responsible for changing the color of the brush.
     """
     color = ctx.triggered_id["index"]
+    if all(v is None for v in color_value):
+        color = current_style[-1]["background-color"]
     for i in range(len(current_style)):
         if current_style[i]["background-color"] == color:
             current_style[i]["border"] = "3px solid black"
@@ -272,9 +274,15 @@ def add_delete_classes(
     annotation_store,
     image_idx,
 ):
-    """Updates the list of available annotation classes"""
+    """
+    Updates the list of available annotation classes,
+    triggers other things that should happen when classes
+    are added or deleted like removing annotations or updating
+    the drawing mode.
+    """
     triggered = ctx.triggered_id
     image_idx = str(image_idx - 1)
+    patched_figure = Patch()
     current_stored_classes = annotation_store["label_mapping"]
     if class_color is None:
         class_color = "rgb(255,255,255)"
@@ -340,7 +348,6 @@ def add_delete_classes(
                 color_to_keep.append(color)
         annotation_store["label_mapping"] = current_stored_classes
         annotation_store["annotations"] = annotations_to_keep
-        patched_figure = Patch()
         if image_idx in annotation_store["annotations"]:
             patched_figure["layout"]["shapes"] = annotation_store["annotations"][
                 image_idx

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -151,6 +151,16 @@ def layout():
                                         ),
                                         dmc.Tooltip(
                                             dmc.ActionIcon(
+                                                id="line",
+                                                variant="outline",
+                                                color="gray",
+                                                children=DashIconify(icon="ci:line-l"),
+                                            ),
+                                            label="Line: draw a straight line",
+                                            multiline=True,
+                                        ),
+                                        dmc.Tooltip(
+                                            dmc.ActionIcon(
                                                 id="circle",
                                                 variant="outline",
                                                 color="gray",
@@ -180,7 +190,7 @@ def layout():
                                                 color="gray",
                                                 children=DashIconify(icon="ph:eraser"),
                                             ),
-                                            label="Eraser: click on shapes to delete them",
+                                            label="Eraser: click on the shape to erase then click this button to delete the selected shape",
                                             multiline=True,
                                         ),
                                         dmc.Tooltip(
@@ -312,6 +322,7 @@ def layout():
                                                 variant="light",
                                             ),
                                         ),
+                                        html.Div(id="bad-label-color"),
                                     ],
                                 ),
                                 dmc.Modal(
@@ -336,10 +347,12 @@ def layout():
                                                 ),
                                             ]
                                         ),
-                                        dmc.Text(
-                                            "There must be at least one annotation class!",
-                                            color="red",
-                                            id="at-least-one",
+                                        dmc.Center(
+                                            dmc.Text(
+                                                "There must be at least one annotation class!",
+                                                color="red",
+                                                id="at-least-one",
+                                            ),
                                         ),
                                     ],
                                 ),
@@ -385,7 +398,7 @@ def layout():
                             {
                                 "color": "rgb(249,82,82)",
                                 "label": "1",
-                                "id": random.randint(1, 100),
+                                "id": "1",
                             }
                         ],
                     },

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -13,21 +13,8 @@ COMPONENT_STYLE = {
 }
 
 FIGURE_CONFIG = {
-    "modeBarButtonsToAdd": [
-        "drawopenpath",
-        "drawclosedpath",
-        "eraseshape",
-        "drawline",
-        "drawcircle",
-        "drawrect",
-    ],
+    "displayModeBar": False,
     "scrollZoom": True,
-    "modeBarButtonsToRemove": [
-        "zoom",
-        "zoomin",
-        "zoomout",
-        "autoscale",
-    ],
 }
 
 


### PR DESCRIPTION
I closed the other PR in favour of this branch where I've resolved merge conflicts with the work done during the onsite. This closes #34 and achieves the following:
- [x] Add a "delete all" button which has a pop up modal warning the user before deleting
- [x] Add an eraser mode
- [x] Remove the tool bar hover from the graph
- [ ] while the user is in the modal for picking a color, every time they select new color the loading overlay triggers for half a second - it looks off
- [x] would it be possible to select a newly created class automatically? right now user continues drawing with the old one
- [ ] can we change it so that max 4/5 labels are in one row, otherwise they start in the next row
- [x] can you also store annotation color inside the `annotation-store` object, so that we can "load them back in" in the future when the user decides to continue with the project (don't worry about loading here, just store the color or whatever else is needed to create them)
- [ ] I don't think this was caused by this branch but on my PC, and multiple browsers, when I hover over the annotation tool images and the info tooltip pops up, the tooltip has a width of around 50px and dragged vertically ~one word in a line  > yeah I saw that, it was caused by a previous branch, not sure which though and having trouble styling this. 
- [x] Add a straight line annotation option
- [x] delete all annotations associated with a class when you delete the class
- [ ] add a warning for deleting the classes
- [ ] add functionality to edit the class labels