### PR TITLE
✨ Session loading saving

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -556,7 +556,7 @@ def toggle_ssave_load_modal(n_clicks, opened):
     State("project-name-src", "value"),
     prevent_initial_call=True,
 )
-def populate_load_server_annotations(modal_opened, image_src):
+def populate_load_annotations_dropdown_menu_options(modal_opened, image_src):
     """
     This callback populates dropdown window with all saved annotation options for the given project name.
     It then creates buttons with info about the save, which when clicked, loads the data from the server.

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -521,6 +521,8 @@ def save_data(n_clicks, annotation_store, image_src):
     """
     if not n_clicks:
         raise PreventUpdate
+    if annotation_store["annotations"] == {}:
+        return "No annotations to save!"
 
     # TODO: save store to the server file-user system, this will be changed to DB later
     export_data = {

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -402,11 +402,85 @@ def layout():
                                 dmc.Space(h=20),
                                 dmc.Center(
                                     dmc.Button(
-                                        "Export annotation",
-                                        id="export-annotation",
+                                        "Save/Load/Export",
+                                        id="open-data-management-modal-button",
                                         variant="light",
                                         style={"width": "160px", "margin": "5px"},
                                     ),
+                                ),
+                                dmc.Modal(
+                                    title="Data Management",
+                                    id="data-management-modal",
+                                    centered=True,
+                                    zIndex=10000,
+                                    children=[
+                                        dmc.Divider(
+                                            variant="solid",
+                                            label="Save data",
+                                            labelPosition="center",
+                                        ),
+                                        dmc.Center(
+                                            dmc.Button(
+                                                "Save to server",
+                                                id="save-annotations",
+                                                variant="light",
+                                                style={
+                                                    "width": "160px",
+                                                    "margin": "5px",
+                                                },
+                                            ),
+                                        ),
+                                        dmc.Text(
+                                            id="data-modal-save-status",
+                                            align="center",
+                                            italic=True,
+                                        ),
+                                        dmc.Space(h=20),
+                                        dmc.Divider(
+                                            variant="solid",
+                                            label="Load data",
+                                            labelPosition="center",
+                                        ),
+                                        dmc.Space(h=10),
+                                        dmc.Center(
+                                            dmc.HoverCard(
+                                                withArrow=True,
+                                                shadow="md",
+                                                children=[
+                                                    dmc.HoverCardTarget(
+                                                        dmc.Button(
+                                                            "From server",
+                                                            variant="light",
+                                                            style={
+                                                                "width": "160px",
+                                                                "margin": "5px",
+                                                            },
+                                                        )
+                                                    ),
+                                                    dmc.HoverCardDropdown(
+                                                        id="load-annotations-server-container",
+                                                    ),
+                                                ],
+                                            ),
+                                        ),
+                                        dmc.Space(h=20),
+                                        dmc.Divider(
+                                            variant="solid",
+                                            labelPosition="center",
+                                        ),
+                                        dmc.Space(h=10),
+                                        dmc.Center(
+                                            dmc.Button(
+                                                "Export annotation",
+                                                id="export-annotation",
+                                                variant="light",
+                                                style={
+                                                    "width": "160px",
+                                                    "margin": "5px",
+                                                },
+                                            ),
+                                        ),
+                                    ],
                                 ),
                                 dmc.Space(h=20),
                             ],
@@ -504,4 +578,25 @@ def drawer_section(children):
                 opened=True,
             ),
         ]
+    )
+
+
+def class_action_icon(class_color, class_label, label_color):
+    """
+    This component creates an action icon for the given annotation class.
+    """
+    style = {
+        "background-color": class_color,
+        "width": "fit-content",
+        "border": "1px solid black",
+        "color": label_color,
+        "padding": "5px",
+        "margin-right": "10px",
+    }
+    return dmc.ActionIcon(
+        id={"type": "annotation-color", "index": class_color},
+        w=30,
+        variant="filled",
+        style=style,
+        children=class_label,
     )

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -280,30 +280,45 @@ def layout():
                                         "justify-content": "space-evenly",
                                     },
                                 ),
-                                dmc.Space(h=5),
-                                html.Div(
-                                    [
+                                dmc.Space(h=10),
+                                dmc.Group(
+                                    grow=True,
+                                    children=[
                                         dmc.Button(
                                             id="generate-annotation-class",
                                             children="Generate Class",
                                             variant="outline",
-                                            style={"padding": "0px 12px"},
+                                            leftIcon=DashIconify(
+                                                icon="ic:baseline-plus"
+                                            ),
                                         ),
                                         dmc.Button(
                                             id="edit-annotation-class",
                                             children="Edit Class",
                                             variant="outline",
-                                            style={"padding": "0px 12px"},
+                                            leftIcon=DashIconify(icon="uil:edit"),
+                                        ),
+                                    ],
+                                ),
+                                dmc.Space(h=10),
+                                dmc.Group(
+                                    grow=True,
+                                    children=[
+                                        dmc.Button(
+                                            id="hide-annotation-class",
+                                            children="Hide/Show Classes",
+                                            variant="outline",
+                                            leftIcon=DashIconify(icon="mdi:hide"),
                                         ),
                                         dmc.Button(
                                             id="delete-annotation-class",
-                                            children="Delete Class",
+                                            children="Delete Classes",
                                             variant="outline",
-                                            style={"padding": "0px 12px"},
+                                            leftIcon=DashIconify(
+                                                icon="octicon:trash-24"
+                                            ),
                                         ),
                                     ],
-                                    className="flex-row",
-                                    style={"justify-content": "space-evenly"},
                                 ),
                                 dmc.Modal(
                                     id="generate-annotation-class-modal",
@@ -345,7 +360,7 @@ def layout():
                                         dmc.Center(
                                             dmc.TextInput(
                                                 id="annotation-class-label-edit",
-                                                placeholder="New Annotation Class Label",
+                                                placeholder="New Class Label",
                                             ),
                                         ),
                                         dmc.Space(h=10),
@@ -357,6 +372,36 @@ def layout():
                                             ),
                                         ),
                                         html.Div(id="bad-label"),
+                                    ],
+                                ),
+                                dmc.Modal(
+                                    id="hide-annotation-class-modal",
+                                    title="Hide/Show Annotation Classes",
+                                    children=[
+                                        dmc.Text("Select annotation classes to hide:"),
+                                        html.Div(
+                                            id="current-annotation-classes-hide",
+                                            style={
+                                                "display": "flex",
+                                                "flex-wrap": "wrap",
+                                                "justify-content": "space-evenly",
+                                            },
+                                        ),
+                                        dmc.Space(h=10),
+                                        dmc.Center(
+                                            dmc.Button(
+                                                id="conceal-annotation-class",
+                                                children="Apply Changes",
+                                                variant="light",
+                                            ),
+                                        ),
+                                        dmc.Center(
+                                            dmc.Text(
+                                                "No classes selected",
+                                                color="red",
+                                                id="at-least-one-hide",
+                                            ),
+                                        ),
                                     ],
                                 ),
                                 dmc.Modal(

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 import requests
 from urllib.parse import urlparse
 
@@ -52,6 +53,39 @@ def DEV_download_google_sample_data():
             print(f"Downloaded {destination}")
 
     print("All files downloaded successfully.")
+
+
+def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):
+    """
+    This function is used to load the exported json, which was saved in a local file.
+    User name is used to filter the data by user.
+    Project name is used to filter the data by project.
+    It is sorted by timestamp with the latest timestamp first.
+
+    TODO: this function will be replaced with a database query in the future.
+    """
+    DATA_JSON = []
+
+    with open(file_path, "r") as f:
+        for line in f:
+            if line.strip():
+                json_data = json.loads(line)
+                json_data["data"] = json.loads(json_data["data"])
+                DATA_JSON.append(json_data)
+
+    data = [
+        data
+        for data in DATA_JSON
+        if data["user"] == USER_NAME and data["source"] == PROJECT_NAME
+    ]
+    if data:
+        data = sorted(data, key=lambda x: x["time"], reverse=True)
+
+    return data
+
+
+def DEV_filter_json_data_by_timestamp(data, timestamp):
+    return [data for data in data if data["time"] == timestamp]
 
 
 load_dotenv()


### PR DESCRIPTION
This PR introduces loading and saving annotations.

- All existing project annotations can be saved by pressing a save button in the save/load/export menu
- if no annotations exist, it won't let the user save and will inform them that no annotations exist
- Users can go to the save/load/export menu and will see all saved annotations for that given user and the project they currently have selected. 
- if the project contains no new annotations it will inform the user by saying so
- when a user loads the annotations, the modal will be closed, and all annotations are loaded into the "annotation-store", figure if the data contains annotations for the currently selected slice, it will update the figure with those annotations