### PR TITLE
Resize plot to full-screen

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from dash import Dash, dcc
+from dash import Dash, dcc, clientside_callback, ClientsideFunction
 import dash_mantine_components as dmc
 from components.control_bar import layout as control_bar_layout
 from components.image_viewer import layout as image_viewer_layout
@@ -12,12 +12,8 @@ server = app.server
 app.layout = dmc.MantineProvider(
     theme={"colorScheme": "light"},
     children=[
-        dmc.Group(
-            children=[
-                control_bar_layout(),
-                image_viewer_layout(),
-            ],
-        ),
+        control_bar_layout(),
+        image_viewer_layout(),
         dcc.Store(id="current-ann-mode"),
     ],
 )

--- a/assets/functions.js
+++ b/assets/functions.js
@@ -6,3 +6,58 @@ function changeFilters(js_path, brightness, contrast) {
         element.style.webkitFilter = `brightness(${brightness}%) contrast(${contrast}%)`;
     }
 }
+
+
+
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    clientside: {
+        get_container_size: function(url) {
+            let W = window.innerWidth;
+            let H = window.innerHeight;
+            if(W == 0 || H == 0){
+                return dash_clientside.no_update
+            }
+            return {'W': W, 'H':H}
+        },
+        resize_canvas: function(metadata, figure) {
+            let h = metadata.size[0];
+            let w = metadata.size[1];
+            let W = window.innerWidth;
+            let H = window.innerHeight;
+            let screen_ratio = W/H;  
+            let img_ratio = w/h;
+            if (w<=W && h<=H){
+                figure.layout.xaxis.range[1] = W-(W-w)/2;
+                figure.layout.xaxis.range[0] = -(W-w)/2;
+                figure.layout.yaxis.range[1] = H-(H-h)/2;
+                figure.layout.yaxis.range[0] = -(H-h)/2;
+            }else if(w>W){
+                if(img_ratio<=screen_ratio){
+
+                    figure.layout.xaxis.range[1] = h*screen_ratio - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.xaxis.range[0] = - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.yaxis.range[1] = h;
+                    figure.layout.yaxis.range[0] = 0;
+                }else{
+                    figure.layout.xaxis.range[1] = w;
+                    figure.layout.xaxis.range[0] = 0;
+                    figure.layout.yaxis.range[1] = w/screen_ratio - w*(1/screen_ratio-1/img_ratio)/2;
+                    figure.layout.yaxis.range[0] = - w*(1/screen_ratio-1/img_ratio)/2;
+                }
+            }else if (w<W && h>H){   
+                if(w>=h){
+                    figure.layout.xaxis.range[1] = w*(screen_ratio/img_ratio) - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.xaxis.range[0] = 0 - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.yaxis.range[1] = h;
+                    figure.layout.yaxis.range[0] = 0;
+                }else{
+                    figure.layout.xaxis.range[1] = w*(screen_ratio/img_ratio) - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.xaxis.range[0] = 0 - h*(screen_ratio-img_ratio)/2;
+                    figure.layout.yaxis.range[1] = h;
+                    figure.layout.yaxis.range[0] = 0;
+                }
+            }
+            return figure;
+        },
+    }
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -24,3 +24,8 @@
     top: 0;
     right: 0;
 }
+
+body{
+    margin: 0px;
+    padding: 0px;
+}

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -4,11 +4,8 @@ from dash_iconify import DashIconify
 from utils.plot_utils import blank_fig
 
 COMPONENT_STYLE = {
-    "width": "calc(-440px + 100vw)",
-    "height": "calc(100vh - 40px)",
-    "padding": "10px",
-    "borderRadius": "5px",
-    "border": "1px solid rgb(222, 226, 230)",
+    "width": "100vw",
+    "height": "100vh",
     "overflowY": "auto",
 }
 
@@ -22,6 +19,9 @@ def layout():
     return html.Div(
         style=COMPONENT_STYLE,
         children=[
+            dcc.Store("image-metadata", data={"name": None}),
+            dcc.Store("screen-size"),
+            dcc.Location("url"),
             dmc.LoadingOverlay(
                 id="image-viewer-loading",
                 overlayOpacity=0.15,
@@ -33,16 +33,30 @@ def layout():
                         id="image-viewer",
                         config=FIGURE_CONFIG,
                         figure=blank_fig(),
-                        style={"margin": "auto", "height": "calc(-150px + 100vh)"},
+                        style={
+                            "width": "100vw",
+                            "height": "100vh",
+                            "position": "fixed",
+                            "z-index": 1,
+                        },
                     ),
                     dcc.Graph(
                         id="image-viewfinder",
                         figure=blank_fig(),
                         config={"displayModeBar": False},
-                        style={"width": "10vh", "height": "10vh"},
+                        style={
+                            "width": "10vh",
+                            "height": "10vh",
+                            "position": "absolute",
+                            "top": "30px",
+                            "right": "10px",
+                            "z-index": 10,
+                        },
                     ),
                 ],
-                style={"display": "flex"},
+                style={
+                    "display": "flex",
+                },
             ),
         ],
     )

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -44,14 +44,6 @@ def layout():
                         id="image-viewfinder",
                         figure=blank_fig(),
                         config={"displayModeBar": False},
-                        style={
-                            "width": "10vh",
-                            "height": "10vh",
-                            "position": "absolute",
-                            "top": "30px",
-                            "right": "10px",
-                            "z-index": 10,
-                        },
                     ),
                 ],
                 style={

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -181,6 +181,8 @@ def resize_canvas(h, w, H, W, figure):
             x0 = 0 - h * (screen_ratio - img_ratio) / 2
             y1 = h
             y0 = 0
+
+    figure.update_yaxes(range=[y1, y0])
     figure.update_xaxes(range=[x0, x1])
-    figure.update_yaxes(range=[y0, y1])
+
     return figure

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -113,3 +113,39 @@ def create_viewfinder(image_data, annotation_store, downscaled_image_shape):
         hovermode=False,
     )
     return fig
+
+
+def resize_canvas(h, w, H, W, figure):
+    img_ratio = w / h
+    screen_ratio = W / H
+    if w <= W and h <= H:
+        x1 = W - (W - w) / 2
+        x0 = -(W - w) / 2
+        y1 = H - (H - h) / 2
+        y0 = -(H - h) / 2
+    elif w > W:
+        if img_ratio <= screen_ratio:
+            x1 = h * screen_ratio - h * (screen_ratio - img_ratio) / 2
+            x0 = -h * (screen_ratio - img_ratio) / 2
+            y1 = h
+            y0 = 0
+        else:
+            x1 = w
+            x0 = 0
+            y1 = w / screen_ratio - w * (1 / screen_ratio - 1 / img_ratio) / 2
+            y0 = -w * (1 / screen_ratio - 1 / img_ratio) / 2
+
+    elif w < W and h > H:
+        if w >= h:
+            x1 = w * (screen_ratio / img_ratio) - h * (screen_ratio - img_ratio) / 2
+            x0 = 0 - h * (screen_ratio - img_ratio) / 2
+            y1 = h
+            y0 = 0
+        else:
+            x1 = w * (screen_ratio / img_ratio) - h * (screen_ratio - img_ratio) / 2
+            x0 = 0 - h * (screen_ratio - img_ratio) / 2
+            y1 = h
+            y0 = 0
+    figure.update_xaxes(range=[x0, x1])
+    figure.update_yaxes(range=[y0, y1])
+    return figure

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -46,7 +46,7 @@ def downscale_view(
     return x0, y0, x1, y1
 
 
-def create_viewfinder(image_data, annotation_store, downscaled_image_shape):
+def create_viewfinder(image_data, downscaled_image_shape, view):
     """
     Creates a viewfinder for the image viewer. The viewfinder is a small box that shows the current view of the image
     in the image viewer. It is used to quickly navigate to different parts of the image.
@@ -59,25 +59,30 @@ def create_viewfinder(image_data, annotation_store, downscaled_image_shape):
     fig = px.imshow(
         img_resized,
         binary_string=True,
-        width=img_max_height,
-        height=img_max_width,
+        width=img_max_width,
+        height=img_max_height,
     )
 
-    view = annotation_store["view"]
-    if "xaxis_range_0" in view:
-        x0, y0, x1, y1 = downscale_view(
-            view["xaxis_range_0"],
-            view["yaxis_range_1"],
-            view["xaxis_range_1"],
-            view["yaxis_range_0"],
-            image_data.shape,
-            (img_max_height, img_max_width),
-        )
-    else:
-        x0 = 0
-        y0 = img_max_height
-        x1 = img_max_width
-        y1 = 0
+    x0 = 0
+    y0 = 0
+    x1 = img_max_width
+    y1 = img_max_height
+
+    if view:
+        if "xaxis_range_0" in view:
+            x0, y0, x1, y1 = downscale_view(
+                view["xaxis_range_0"],
+                view["yaxis_range_1"],
+                view["xaxis_range_1"],
+                view["yaxis_range_0"],
+                image_data.shape,
+                (img_max_height, img_max_width),
+            )
+        else:
+            x0 = 0
+            y0 = img_max_height
+            x1 = img_max_width
+            y1 = 0
 
     # Create the viewfinder box
     fig.add_shape(
@@ -113,6 +118,36 @@ def create_viewfinder(image_data, annotation_store, downscaled_image_shape):
         hovermode=False,
     )
     return fig
+
+
+def get_viewfinder_style(image_ratio):
+    if image_ratio < 1:
+        return (
+            {
+                "width": f"calc(10vh/{image_ratio})",
+                "height": f"10vh",
+                "position": "absolute",
+                "top": "30px",
+                "right": "10px",
+            },
+        )
+    else:
+        return (
+            {
+                "width": "10vh",
+                "height": f"calc(10vh/{image_ratio})",
+                "position": "absolute",
+                "top": "30px",
+                "right": "10px",
+            },
+        )
+
+
+def get_view_finder_max_min(image_ratio):
+    if image_ratio < 1:
+        return 250, 250 * image_ratio
+    else:
+        return 250 / image_ratio, 250
 
 
 def resize_canvas(h, w, H, W, figure):


### PR DESCRIPTION
- Add back full screen graph feature.
- Adjust view-finder dimensions for none square images
- Clean up redundant callback firings that keep re-rendering figure
Note: To avoid the image-viewer from re-rendering multiple times, added a dcc.Store that will save screen size only once on first load and moved the client side canvas resizer to a backend function the main renger_image callback will use.