### PR TITLE
Add segmentation result overlay

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -25,6 +25,7 @@ from utils.data_utils import (
 
 import os
 import time
+from utils import data_utils
 
 # TODO - temporary local file path and user for annotation saving and exporting
 EXPORT_FILE_PATH = "data/exported_annotation_data.json"
@@ -908,3 +909,46 @@ def open_controls_drawer(is_opened):
     if is_opened:
         raise PreventUpdate
     return {"padding-left": "125px"}
+
+
+@callback(
+    Output("result-selector", "data"),
+    Output("result-selector", "value"),
+    Output("overlay-switch-container", "children"),
+    Input("project-name-src", "value"),
+)
+def populate_classification_results(image_src):
+    results = [
+        item
+        for item in data_utils.get_data_project_names()
+        if ("seg" in item and image_src in item)
+    ]
+    if results:
+        value = results[0]
+        switch = (
+            dmc.Switch(
+                id="show-result-overlay",
+                size="sm",
+                radius="lg",
+                color="gray",
+                label="View segmentation overlay",
+                checked=True,
+                disabled=False,
+                styles={"trackLabel": {"cursor": "pointer"}},
+            ),
+        )
+    else:
+        value = None
+        switch = (
+            dmc.Switch(
+                id="show-result-overlay",
+                size="sm",
+                radius="lg",
+                color="gray",
+                label="View segmentation overlay",
+                checked=False,
+                disabled=True,
+                styles={"trackLabel": {"cursor": "pointer"}},
+            ),
+        )
+    return results, value, switch

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -20,11 +20,6 @@ from dash import (
 from dash.exceptions import PreventUpdate
 from dash_iconify import DashIconify
 
-<<<<<<< HEAD
-import os
-import time
-from utils import data_utils
-=======
 from components.control_bar import class_action_icon
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEYBINDS
 from utils.annotations import Annotations
@@ -32,7 +27,10 @@ from utils.data_utils import (
     DEV_filter_json_data_by_timestamp,
     DEV_load_exported_json_data,
 )
->>>>>>> main
+
+import os
+import time
+from utils import data_utils
 
 # TODO - temporary local file path and user for annotation saving and exporting
 EXPORT_FILE_PATH = "data/exported_annotation_data.json"
@@ -910,9 +908,8 @@ def open_controls_drawer(n_clicks):
 )
 def open_controls_drawer(is_opened):
     if is_opened:
-<<<<<<< HEAD
-        raise PreventUpdate
-    return {"padding-left": "125px"}
+        return {"display": "none"}
+    return {}
 
 
 @callback(
@@ -929,34 +926,27 @@ def populate_classification_results(image_src):
     ]
     if results:
         value = results[0]
-        switch = (
-            dmc.Switch(
-                id="show-result-overlay",
-                size="sm",
-                radius="lg",
-                color="gray",
-                label="View segmentation overlay",
-                checked=True,
-                disabled=False,
-                styles={"trackLabel": {"cursor": "pointer"}},
-            ),
+        switch = dmc.Switch(
+            id="show-result-overlay",
+            size="sm",
+            radius="lg",
+            color="gray",
+            label="View segmentation overlay",
+            checked=True,
+            disabled=False,
+            styles={"trackLabel": {"cursor": "pointer"}},
         )
+
     else:
         value = None
-        switch = (
-            dmc.Switch(
-                id="show-result-overlay",
-                size="sm",
-                radius="lg",
-                color="gray",
-                label="View segmentation overlay",
-                checked=False,
-                disabled=True,
-                styles={"trackLabel": {"cursor": "pointer"}},
-            ),
+        switch = dmc.Switch(
+            id="show-result-overlay",
+            size="sm",
+            radius="lg",
+            color="gray",
+            label="View segmentation overlay",
+            checked=False,
+            disabled=True,
+            styles={"trackLabel": {"cursor": "pointer"}},
         )
     return results, value, switch
-=======
-        return {"display": "none"}
-    return {}
->>>>>>> main

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -18,25 +18,35 @@ DOWNSCALED_img_max_height, DOWNSCALED_img_max_width = 250, 250
     Output("image-transformation-controls", "children", allow_duplicate=True),
     Output("annotations-controls", "children", allow_duplicate=True),
     Input("image-selection-slider", "value"),
+    Input("show-result-overlay", "checked"),
     State("project-name-src", "value"),
     State("paintbrush-width", "value"),
     State("annotation-class-selection", "children"),
     State("annotation-store", "data"),
+    State("result-selector", "value"),
     prevent_initial_call=True,
 )
 def render_image(
     image_idx,
+    toggle_result,
     project_name,
     annotation_width,
     annotation_colors,
     annotation_store,
+    result_name,
 ):
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
         tf = data[project_name][image_idx]
+        if toggle_result:
+            result = data[result_name][image_idx]
+            tf = 0.1 * tf + 0.9 * result
+
     else:
         tf = np.zeros((500, 500))
+
     fig = px.imshow(tf, binary_string=True)
+
     fig.update_layout(
         margin=dict(l=0, r=0, t=0, b=0),
         xaxis=dict(visible=False),
@@ -46,7 +56,6 @@ def render_image(
         plot_bgcolor="rgba(0,0,0,0)",
     )
     fig.update_traces(hovertemplate=None, hoverinfo="skip")
-
     # set the default annotation style
     for color_opt in annotation_colors:
         if color_opt["props"]["style"]["border"] != "1px solid":

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -29,7 +29,9 @@ def _accordion_item(title, icon, value, children, id):
 
 
 def layout():
-    DATA_OPTIONS = data_utils.get_data_project_names()
+    DATA_OPTIONS = [
+        item for item in data_utils.get_data_project_names() if "seg" not in item
+    ]
     return drawer_section(
         dmc.Stack(
             style={"width": "400px"},
@@ -549,6 +551,28 @@ def layout():
                                     id="run-model",
                                     variant="light",
                                     style={"width": "160px", "margin": "5px"},
+                                ),
+                                html.Div(
+                                    id="overlay-switch-container",
+                                    children=[
+                                        dmc.Switch(
+                                            id="show-result-overlay",
+                                            size="sm",
+                                            radius="lg",
+                                            color="gray",
+                                            label="View segmentation overlay",
+                                            checked=False,
+                                            disabled=True,
+                                            styles={
+                                                "trackLabel": {"cursor": "pointer"}
+                                            },
+                                        ),
+                                    ],
+                                ),
+                                dmc.Text("Results"),
+                                dmc.Select(
+                                    id="result-selector",
+                                    placeholder="Select an ML result...",
                                 ),
                                 html.Div(id="output-placeholder"),
                             ],


### PR DESCRIPTION
- Look for results matching the project name in the server and populate a dropdown if they exist. (Remove these results from the "project-name-src" dropdown as well.)
- Overlay a selected segmentation result if toggle is on.
<img width="809" alt="Screenshot 2023-08-18 at 1 44 22 PM" src="https://github.com/mlexchange/mlex_highres_segmentation/assets/59619336/ec82b720-2a6e-4332-80c7-421656d55be3">
Note:
Should decide how and where to showcase this dropdown and toggle for results:
<img width="402" alt="Screenshot 2023-08-18 at 1 44 09 PM" src="https://github.com/mlexchange/mlex_highres_segmentation/assets/59619336/f3530c25-a3fd-4ef5-b586-dc9a2d5713a3">
