### PR TITLE
⬆️ Update version of Tiled and adopt new server structure

### DIFF
--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -15,7 +15,7 @@ import plotly.express as px
 import numpy as np
 import random
 from dash_iconify import DashIconify
-from utils.data_utils import get_data_sequence_by_name
+from utils.data_utils import get_data_shape_by_name, get_data_sequence_by_name
 from constants import KEYBINDS, ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS
 from utils.plot_utils import (
     create_viewfinder,
@@ -306,14 +306,16 @@ def update_slider_values(project_name, annotation_store):
     ## todo - change Input("project-name-src", "data") to value when image-src will contain buckets of data and not just one image
     ## todo - eg, when a different image source is selected, update slider values which is then used to select image within that source
     """
-
-    disable_slider = project_name is None
+    # Retrieve data shape if project_name is valid and points to a 3d array
+    data_shape = (
+        get_data_shape_by_name(project_name) if not project_name is None else None
+    )
+    disable_slider = data_shape is None
     if not disable_slider:
-        sequence = get_data_sequence_by_name(project_name)
         # TODO: Assuming that all slices have the same image shape
-        annotation_store["image_shapes"] = [(sequence.shape[1], sequence.shape[2])]
+        annotation_store["image_shapes"] = [(data_shape[1], data_shape[2])]
     min_slider_value = 0 if disable_slider else 1
-    max_slider_value = 0 if disable_slider else len(sequence)
+    max_slider_value = 0 if disable_slider else data_shape[0]
     slider_value = 0 if disable_slider else 1
     annotation_store["annotations"] = {}
     annotation_store["view"] = {}

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -15,7 +15,7 @@ import plotly.express as px
 import numpy as np
 import random
 from dash_iconify import DashIconify
-from utils.data_utils import data
+from utils.data_utils import get_data_sequence_by_name
 from constants import KEYBINDS, ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS
 from utils.plot_utils import (
     create_viewfinder,
@@ -60,7 +60,7 @@ def render_image(
 ):
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
-        tf = data[project_name][image_idx]
+        tf = get_data_sequence_by_name(project_name)[image_idx]
     else:
         tf = np.zeros((500, 500))
 
@@ -309,11 +309,11 @@ def update_slider_values(project_name, annotation_store):
 
     disable_slider = project_name is None
     if not disable_slider:
-        tiff_file = data[project_name]
+        sequence = get_data_sequence_by_name(project_name)
         # TODO: Assuming that all slices have the same image shape
-        annotation_store["image_shapes"] = [(tiff_file.shape[1], tiff_file.shape[2])]
+        annotation_store["image_shapes"] = [(sequence.shape[1], sequence.shape[2])]
     min_slider_value = 0 if disable_slider else 1
-    max_slider_value = 0 if disable_slider else len(tiff_file)
+    max_slider_value = 0 if disable_slider else len(sequence)
     slider_value = 0 if disable_slider else 1
     annotation_store["annotations"] = {}
     annotation_store["view"] = {}

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -1,6 +1,6 @@
 from dash import callback, Input, Output, State, no_update
 from utils.annotations import Annotations
-from utils.data_utils import data
+from utils.data_utils import get_data_sequence_by_name
 import numpy as np
 
 
@@ -16,7 +16,6 @@ import numpy as np
 def run_job(n_clicks, annotation_store, project_name):
     # As a placeholder, pulling together the inputs we'd need if we were going to submit a job
     if n_clicks:
-
         annotations = Annotations(annotation_store)
         annotations.create_annotation_metadata()
         annotations.create_annotation_mask(
@@ -30,7 +29,7 @@ def run_job(n_clicks, annotation_store, project_name):
         # Get raw images associated with each annotated slice
         # Actually we can just pass the indices and have the job point to Tiled directly
         img_idx = list(metadata.keys())
-        img = data[project_name]
+        img = get_data_sequence_by_name(project_name)
         raw = []
         for idx in img_idx:
             ar = img[int(idx)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tifffile==2023.4.12
 tzdata==2023.3
 Werkzeug==2.2.3
 zipp==3.15.0
-tiled[client]==0.1.0a96
+tiled[client]==0.1.0a105
 gunicorn==20.1.0
 requests==2.26.0
 python-dotenv

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -96,9 +96,9 @@ TILED_URI = os.getenv("TILED_URI")
 API_KEY = os.getenv("API_KEY")
 
 if os.getenv("SERVE_LOCALLY", False):
-    print("To run Tiled server locally run `tiled serve directory --public data`")
-    print("This requires to additional install the server components of Tiled")
-    print('with `pip install "tiled[server]"`')
+    print("To run a Tiled server locally run `tiled serve directory --public data`.")
+    print("This requires to additionally install the server components of Tiled with:")
+    print('`pip install "tiled[server]"`')
     DEV_download_google_sample_data()
     client = from_uri("http://localhost:8000")
     data = client

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -120,7 +120,7 @@ def get_data_project_names():
     return project_names
 
 
-def get_client_by_name(project_name):
+def get_data_sequence_by_name(project_name):
     """
     Data sequences may be given directly inside the main client container,
     but can also be additionally encapsulated in a folder.
@@ -139,21 +139,11 @@ def get_client_by_name(project_name):
     return None
 
 
-def get_data_sequence_by_name(project_name):
-    """
-    Retrieve data as an array
-    """
-    project_container = get_client_by_name(project_name)
-    if not project_container is None:
-        return project_container.read()
-    return None
-
-
 def get_data_shape_by_name(project_name):
     """
     Retrieve shape of the data
     """
-    project_container = get_client_by_name(project_name)
+    project_container = get_data_sequence_by_name(project_name)
     if not project_container is None:
         return project_container.shape
     return None

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -120,20 +120,40 @@ def get_data_project_names():
     return project_names
 
 
-def get_data_sequence_by_name(project_name):
+def get_client_by_name(project_name):
     """
     Data sequences may be given directly inside the main client container,
     but can also be additionally encapsulated in a folder.
     """
-    project_data = data[project_name]
+    project_client = data[project_name]
     # If the project directly points to an array
-    if isinstance(project_data, ArrayClient):
-        return project_data.read()
+    if isinstance(project_client, ArrayClient):
+        return project_client
     # If project_name points to a container
-    elif isinstance(project_data, Container):
+    elif isinstance(project_client, Container):
         # Enter the container and return first element
-        if len(list(project_data)) == 1:
-            sequence = project_data.values()[0]
-            if isinstance(sequence, ArrayClient):
-                return sequence.read()
-    return []
+        if len(list(project_client)) == 1:
+            sequence_client = project_client.values()[0]
+            if isinstance(sequence_client, ArrayClient):
+                return sequence_client
+    return None
+
+
+def get_data_sequence_by_name(project_name):
+    """
+    Retrieve data as an array
+    """
+    project_container = get_client_by_name(project_name)
+    if not project_container is None:
+        return project_container.read()
+    return None
+
+
+def get_data_shape_by_name(project_name):
+    """
+    Retrieve shape of the data
+    """
+    project_container = get_client_by_name(project_name)
+    if not project_container is None:
+        return project_container.shape
+    return None


### PR DESCRIPTION
This updates the version of Tiled to the latest release.
In this release, tiff-sequences are added to the client tree in a different way than before and the retrieval of data is thus now wrapped in an additional function that makes sure we always still retrieve an array.

The PR also prepares for the server update on Spin where we will store additional data along-side the reconstructed data (e.g. raw data from the detector images, user-specific data such as masks and job results) and thus accesses only the `reconstruction` container to populate the project drop-down.

⚠️ Merging this PR needs to coordinated with the Server update as Tiled server and client versions need to be compatible.