### PR TITLE
Change class color

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ app.layout = dmc.MantineProvider(
     children=[
         control_bar_layout(),
         image_viewer_layout(),
-        dcc.Store(id="current-class-selection", data="rgb(22,17,79)"),
+        dcc.Store(id="current-class-selection", data="#FFA200"),
     ],
 )
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -108,9 +108,13 @@ body {
     border-color: #EAECEF !important;
 }
 
-.add-class-btn:hover,
 .annotation-class:hover {
     background-color: #EAECEF !important;
+    cursor: pointer;
+}
+
+.add-class-btn:hover {
+    background-color: #eaecef24 !important;
     cursor: pointer;
 }
 

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -575,7 +575,7 @@ def clear_annotation_class(
     annotation_class_store,
 ):
     """This callback updates the deleted-class-store with the color of the class to delete"""
-    deleted_class = annotation_class_store["class_id "]
+    deleted_class = annotation_class_store["class_id"]
     return deleted_class
 
 

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -43,13 +43,17 @@ import random
 @callback(
     Output("current-class-selection", "data", allow_duplicate=True),
     Input({"type": "annotation-class", "index": ALL}, "n_clicks"),
+    State({"type": "annotation-class-store", "index": ALL}, "data"),
     prevent_initial_call=True,
 )
-def update_current_class_selection(class_selected):
+def update_current_class_selection(class_selected, all_annotation_classes):
+    print(all_annotation_classes)
     current_selection = None
     if ctx.triggered_id:
         if len(ctx.triggered) == 1:
-            current_selection = ctx.triggered_id["index"]
+            for c in all_annotation_classes:
+                if c["class_id"] == ctx.triggered_id["index"]:
+                    current_selection = c["color"]
         # More than one item in the trigger means the trigger comes from adding a new class.
         # We dont want to reset the current selection in this case
         else:
@@ -60,9 +64,9 @@ def update_current_class_selection(class_selected):
 @callback(
     Output({"type": "annotation-class", "index": ALL}, "style"),
     Input("current-class-selection", "data"),
-    State({"type": "annotation-class", "index": ALL}, "id"),
+    State({"type": "annotation-class-store", "index": ALL}, "data"),
 )
-def update_selected_class_style(selected_class, current_ids):
+def update_selected_class_style(selected_class, all_annotation_classes):
     """
     This callback is responsible for updating the style of the selected annotation class to make it appear
     like it has been "selected"
@@ -82,7 +86,7 @@ def update_selected_class_style(selected_class, current_ids):
         "justifyContent": "space-between",
         "backgroundColor": "#EAECEF",
     }
-    ids = [c["index"] for c in current_ids]
+    ids = [c["color"] for c in all_annotation_classes]
     if selected_class in ids:
         # find index of selected class and change its style
         index = ids.index(selected_class)
@@ -514,7 +518,7 @@ def clear_annotation_class(
     annotation_class_store,
 ):
     """This callback updates the deleted-class-store with the color of the class to delete"""
-    deleted_class = annotation_class_store["color"]
+    deleted_class = annotation_class_store["class_id "]
     return deleted_class
 
 

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -397,6 +397,7 @@ def open_edit_class_modal(
         return no_update, edit_disabled, error_msg, modal_title, no_update, no_update
     # add the current class name and color in the modal. (in case user wants to only edit one thing)
     if ctx.triggered_id["type"] == "edit-annotation-class":
+        print(class_to_edit["color"])
         return (
             not opened,
             no_update,
@@ -438,7 +439,6 @@ def open_delete_class_modal(
     Output({"type": "annotation-class-label", "index": MATCH}, "children"),
     Output({"type": "annotation-class-color", "index": MATCH}, "style"),
     Output({"type": "annotation-class-store", "index": MATCH}, "data"),
-    Output({"type": "edit-annotation-class-text-input", "index": MATCH}, "value"),
     Output({"type": "annotation-class", "index": MATCH}, "n_clicks"),
     Input({"type": "save-edited-annotation-class-btn", "index": MATCH}, "n_clicks"),
     State({"type": "edit-annotation-class-text-input", "index": MATCH}, "value"),
@@ -467,7 +467,7 @@ def edit_annotation_class(
         for a in annotation_class_store["annotations"][img_idx]:
             a["line"]["color"] = new_color
 
-    return new_label, class_color_identifier, annotation_class_store, "", 1
+    return new_label, class_color_identifier, annotation_class_store, 1
 
 
 @callback(

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -439,6 +439,7 @@ def open_delete_class_modal(
     Output({"type": "annotation-class-color", "index": MATCH}, "style"),
     Output({"type": "annotation-class-store", "index": MATCH}, "data"),
     Output({"type": "edit-annotation-class-text-input", "index": MATCH}, "value"),
+    Output({"type": "annotation-class", "index": MATCH}, "n_clicks"),
     Input({"type": "save-edited-annotation-class-btn", "index": MATCH}, "n_clicks"),
     State({"type": "edit-annotation-class-text-input", "index": MATCH}, "value"),
     State({"type": "edit-annotation-class-colorpicker", "index": MATCH}, "value"),
@@ -451,6 +452,7 @@ def edit_annotation_class(
 ):
     """This callback edits the name of an annotation class"""
     img_idx = str(img_idx - 1)
+    # update store meta data
     annotation_class_store["label"] = new_label
     annotation_class_store["color"] = new_color
     class_color_identifier = {
@@ -465,7 +467,7 @@ def edit_annotation_class(
         for a in annotation_class_store["annotations"][img_idx]:
             a["line"]["color"] = new_color
 
-    return new_label, class_color_identifier, annotation_class_store, ""
+    return new_label, class_color_identifier, annotation_class_store, "", 1
 
 
 @callback(

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -134,10 +134,22 @@ def render_image(
     Input("keybind-event-listener", "event"),
     State("image-selection-slider", "value"),
     State("image-selection-slider", "max"),
+    State("generate-annotation-class-modal", "opened"),
+    State({"type": "edit-annotation-class-modal", "index": ALL}, "opened"),
     prevent_initial_call=True,
 )
-def keybind_image_slider(n_events, keybind_event_listener, current_slice, max_slice):
+def keybind_image_slider(
+    n_events,
+    keybind_event_listener,
+    current_slice,
+    max_slice,
+    generate_modal_opened,
+    edit_modal_opened,
+):
     """Allows user to use left/right arrow keys to navigate through images"""
+    if generate_modal_opened or any(edit_modal_opened):
+        raise PreventUpdate
+
     pressed_key = (
         keybind_event_listener.get("key", None) if keybind_event_listener else None
     )

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -23,9 +23,7 @@ def get_action_icon(type, class_id, icon):
 # This function generates a class component with all its buttons (hide/show, edit, delete)
 # The class color is used as an ID to identify a class (as all class colors are unique and cannot be modified)
 def annotation_class_item(class_color, class_label):
-    color = class_color
-    class_color = color.replace("rgb", "rgba")
-    class_color_transparent = class_color[:-1] + ",0.5)"
+    class_color_transparent = class_color + "50"
     class_id = str(uuid.uuid4())
     return html.Div(
         [  # This store will contain all the meta data for an individual annotation class
@@ -36,7 +34,7 @@ def annotation_class_item(class_color, class_label):
                 },
                 data={
                     "annotations": {},
-                    "color": color,
+                    "color": class_color,
                     "label": class_label,
                     "is_visible": True,
                     "class_id": class_id,
@@ -58,7 +56,7 @@ def annotation_class_item(class_color, class_label):
                             "background-color": class_color_transparent,
                             "margin": "5px",
                             "borderRadius": "3px",
-                            "border": f"2px solid {color}",
+                            "border": f"2px solid {class_color}",
                         },
                         id={
                             "type": "annotation-class-color",

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -46,6 +46,10 @@ def annotation_class_item(class_color, class_label):
                 id={"type": "hide-show-class-store", "index": class_id},
                 data={"is_visible": True},
             ),
+            dcc.Store(
+                id={"type": "edit-class-store", "index": class_id},
+                data={"is_visible": True},
+            ),
             html.Div(
                 [
                     # colored box to represent the color of an annotation class

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -3,7 +3,6 @@ from dash import html, dcc
 from dash_iconify import DashIconify
 import uuid
 import dash_bootstrap_components as dbc
-import dash_daq as daq
 
 
 # This fucntion creates the action icons needed for an annoation class: specifically hide/show, edit and delete actions

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -2,6 +2,8 @@ import dash_mantine_components as dmc
 from dash import html, dcc
 from dash_iconify import DashIconify
 import uuid
+import dash_bootstrap_components as dbc
+import dash_daq as daq
 
 
 # This fucntion creates the action icons needed for an annoation class: specifically hide/show, edit and delete actions
@@ -99,13 +101,13 @@ def annotation_class_item(class_color, class_label):
                 children=[
                     html.Div(
                         [
-                            dmc.ColorPicker(
+                            dbc.Input(
+                                type="color",
                                 id={
                                     "type": "edit-annotation-class-colorpicker",
                                     "index": class_id,
                                 },
-                                format="rgb",
-                                value="rgb(255, 0, 0)",
+                                style={"width": 75, "height": 50},
                             ),
                             dmc.Space(w=25),
                             html.Div(

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -154,38 +154,6 @@ def annotation_class_item(class_color, class_label):
                     ),
                 ],
             ),
-            # dmc.Modal(
-            #     id={"type": "edit-annotation-class-modal", "index": class_id},
-            #     title="Edit a Custom Annotation Class",
-            #     children=[
-            #         dmc.TextInput(
-            #             id={
-            #                 "type": "edit-annotation-class-text-input",
-            #                 "index": class_id,
-            #             },
-            #             placeholder="New class name...",
-            #             style={"width": "70%"},
-            #         ),
-            #         html.Div(
-            #             id={"type": "bad-edit-label", "index": class_id},
-            #             style={"color": "red", "fontSize": "12px", "padding": "3px"},
-            #         ),
-            #         dmc.Space(h=25),
-            #         html.Div(
-            #             dmc.Button(
-            #                 id={
-            #                     "type": "relabel-annotation-class-btn",
-            #                     "index": class_id,
-            #                 },
-            #                 children="Save",
-            #             ),
-            #             style={
-            #                 "display": "flex",
-            #                 "justify-content": "flex-end",
-            #             },
-            #         ),
-            #     ],
-            # ),
             dmc.Modal(
                 id={"type": "delete-annotation-class-modal", "index": class_id},
                 children=[

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -58,6 +58,10 @@ def annotation_class_item(class_color, class_label):
                             "borderRadius": "3px",
                             "border": f"2px solid {color}",
                         },
+                        id={
+                            "type": "annotation-class-color",
+                            "index": class_id,
+                        },
                     ),
                     html.Div(
                         class_label,
@@ -93,27 +97,56 @@ def annotation_class_item(class_color, class_label):
                 id={"type": "edit-annotation-class-modal", "index": class_id},
                 title="Edit a Custom Annotation Class",
                 children=[
-                    dmc.TextInput(
-                        id={
-                            "type": "edit-annotation-class-text-input",
-                            "index": class_id,
+                    html.Div(
+                        [
+                            dmc.ColorPicker(
+                                id={
+                                    "type": "edit-annotation-class-colorpicker",
+                                    "index": class_id,
+                                },
+                                format="rgb",
+                                value="rgb(255, 0, 0)",
+                            ),
+                            dmc.Space(w=25),
+                            html.Div(
+                                [
+                                    dmc.TextInput(
+                                        id={
+                                            "type": "edit-annotation-class-text-input",
+                                            "index": class_id,
+                                        },
+                                        placeholder="New class label...",
+                                    ),
+                                    html.Div(
+                                        id={
+                                            "type": "bad-edit-label",
+                                            "index": class_id,
+                                        },
+                                        style={
+                                            "color": "red",
+                                            "fontSize": "12px",
+                                            "padding": "3px",
+                                        },
+                                    ),
+                                ]
+                            ),
+                        ],
+                        style={
+                            "display": "flex",
+                            "justify-content": "flex-row",
+                            "align-items": "center",
                         },
-                        placeholder="New class name...",
-                        style={"width": "70%"},
                     ),
                     html.Div(
-                        id={"type": "bad-edit-label", "index": class_id},
-                        style={"color": "red", "fontSize": "12px", "padding": "3px"},
-                    ),
-                    dmc.Space(h=25),
-                    html.Div(
-                        dmc.Button(
-                            id={
-                                "type": "relabel-annotation-class-btn",
-                                "index": class_id,
-                            },
-                            children="Save",
-                        ),
+                        [
+                            dmc.Button(
+                                id={
+                                    "type": "save-edited-annotation-class-btn",
+                                    "index": class_id,
+                                },
+                                children="Save",
+                            ),
+                        ],
                         style={
                             "display": "flex",
                             "justify-content": "flex-end",
@@ -121,6 +154,38 @@ def annotation_class_item(class_color, class_label):
                     ),
                 ],
             ),
+            # dmc.Modal(
+            #     id={"type": "edit-annotation-class-modal", "index": class_id},
+            #     title="Edit a Custom Annotation Class",
+            #     children=[
+            #         dmc.TextInput(
+            #             id={
+            #                 "type": "edit-annotation-class-text-input",
+            #                 "index": class_id,
+            #             },
+            #             placeholder="New class name...",
+            #             style={"width": "70%"},
+            #         ),
+            #         html.Div(
+            #             id={"type": "bad-edit-label", "index": class_id},
+            #             style={"color": "red", "fontSize": "12px", "padding": "3px"},
+            #         ),
+            #         dmc.Space(h=25),
+            #         html.Div(
+            #             dmc.Button(
+            #                 id={
+            #                     "type": "relabel-annotation-class-btn",
+            #                     "index": class_id,
+            #                 },
+            #                 children="Save",
+            #             ),
+            #             style={
+            #                 "display": "flex",
+            #                 "justify-content": "flex-end",
+            #             },
+            #         ),
+            #     ],
+            # ),
             dmc.Modal(
                 id={"type": "delete-annotation-class-modal", "index": class_id},
                 children=[

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -1,14 +1,15 @@
 import dash_mantine_components as dmc
 from dash import html, dcc
 from dash_iconify import DashIconify
+import uuid
 
 
 # This fucntion creates the action icons needed for an annoation class: specifically hide/show, edit and delete actions
-def get_action_icon(id, color, icon):
+def get_action_icon(type, class_id, icon):
     return dmc.ActionIcon(
         id={
-            "type": id,
-            "index": color,
+            "type": type,
+            "index": class_id,
         },
         variant="subtle",
         color="gray",
@@ -23,24 +24,26 @@ def annotation_class_item(class_color, class_label):
     color = class_color
     class_color = color.replace("rgb", "rgba")
     class_color_transparent = class_color[:-1] + ",0.5)"
+    class_id = str(uuid.uuid4())
     return html.Div(
         [  # This store will contain all the meta data for an individual annotation class
             dcc.Store(
                 id={
                     "type": "annotation-class-store",
-                    "index": color,
+                    "index": class_id,
                 },
                 data={
                     "annotations": {},
                     "color": color,
                     "label": class_label,
                     "is_visible": True,
+                    "class_id": class_id,
                 },
             ),
             # These stores are solely responsible for triggereing a callback when a class is deleted or shown/hidden
-            dcc.Store(id={"type": "deleted-class-store", "index": color}),
+            dcc.Store(id={"type": "deleted-class-store", "index": class_id}),
             dcc.Store(
-                id={"type": "hide-show-class-store", "index": color},
+                id={"type": "hide-show-class-store", "index": class_id},
                 data={"is_visible": True},
             ),
             html.Div(
@@ -60,7 +63,7 @@ def annotation_class_item(class_color, class_label):
                         class_label,
                         id={
                             "type": "annotation-class-label",
-                            "index": color,
+                            "index": class_id,
                         },
                     ),
                 ],
@@ -73,10 +76,10 @@ def annotation_class_item(class_color, class_label):
             ),
             html.Div(
                 [
-                    get_action_icon("hide-annotation-class", color, "mdi:eye"),
-                    get_action_icon("edit-annotation-class", color, "uil:edit"),
+                    get_action_icon("hide-annotation-class", class_id, "mdi:eye"),
+                    get_action_icon("edit-annotation-class", class_id, "uil:edit"),
                     get_action_icon(
-                        "delete-annotation-class", color, "octicon:trash-24"
+                        "delete-annotation-class", class_id, "octicon:trash-24"
                     ),
                 ],
                 style={
@@ -87,19 +90,19 @@ def annotation_class_item(class_color, class_label):
                 },
             ),
             dmc.Modal(
-                id={"type": "edit-annotation-class-modal", "index": color},
+                id={"type": "edit-annotation-class-modal", "index": class_id},
                 title="Edit a Custom Annotation Class",
                 children=[
                     dmc.TextInput(
                         id={
                             "type": "edit-annotation-class-text-input",
-                            "index": color,
+                            "index": class_id,
                         },
                         placeholder="New class name...",
                         style={"width": "70%"},
                     ),
                     html.Div(
-                        id={"type": "bad-edit-label", "index": color},
+                        id={"type": "bad-edit-label", "index": class_id},
                         style={"color": "red", "fontSize": "12px", "padding": "3px"},
                     ),
                     dmc.Space(h=25),
@@ -107,7 +110,7 @@ def annotation_class_item(class_color, class_label):
                         dmc.Button(
                             id={
                                 "type": "relabel-annotation-class-btn",
-                                "index": color,
+                                "index": class_id,
                             },
                             children="Save",
                         ),
@@ -119,7 +122,7 @@ def annotation_class_item(class_color, class_label):
                 ],
             ),
             dmc.Modal(
-                id={"type": "delete-annotation-class-modal", "index": color},
+                id={"type": "delete-annotation-class-modal", "index": class_id},
                 children=[
                     dmc.Center(
                         dmc.Text(
@@ -132,7 +135,7 @@ def annotation_class_item(class_color, class_label):
                             dmc.Button(
                                 id={
                                     "type": "modal-cancel-delete-class-btn",
-                                    "index": color,
+                                    "index": class_id,
                                 },
                                 children="Cancel",
                             ),
@@ -140,7 +143,7 @@ def annotation_class_item(class_color, class_label):
                             dmc.Button(
                                 id={
                                     "type": "modal-continue-delete-class-btn",
-                                    "index": color,
+                                    "index": class_id,
                                 },
                                 children="Confirm",
                                 variant="outline",
@@ -163,5 +166,5 @@ def annotation_class_item(class_color, class_label):
             "justifyContent": "space-between",
         },
         className="annotation-class",
-        id={"type": "annotation-class", "index": color},
+        id={"type": "annotation-class", "index": class_id},
     )

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -430,7 +430,7 @@ def layout():
                                         html.Div(
                                             children=[
                                                 annotation_class_item(
-                                                    "rgb(22,17,79)", "class 1"
+                                                    "#FFA200", "Class 1"
                                                 )
                                             ],
                                             id="annotation-class-container",

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -3,6 +3,7 @@ from dash import html, dcc
 from dash_iconify import DashIconify
 from utils import data_utils
 from constants import ANNOT_ICONS, KEYBINDS
+import dash_bootstrap_components as dbc
 from dash_extensions import EventListener
 from components.annotation_class import annotation_class_item
 
@@ -453,10 +454,11 @@ def layout():
                                     children=[
                                         html.Div(
                                             [
-                                                dmc.ColorPicker(
+                                                dbc.Input(
+                                                    type="color",
                                                     id="annotation-class-colorpicker",
-                                                    format="rgb",
-                                                    value="rgb(255, 0, 0)",
+                                                    style={"width": 75, "height": 50},
+                                                    value="#DB0606",
                                                 ),
                                                 dmc.Space(w=25),
                                                 html.Div(

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ svgpathtools
 matplotlib
 scipy
 dash-extensions==1.0.1
+dash-bootstrap-components==1.5.0


### PR DESCRIPTION
This PR allows a user to modify the color of a class after it has been created. This requires a small refactor to the logic as the code was using the color as the class ID (thinking this was immutable), so now using uuid() instead to create class Ids.
Note: the color picker is now a dbc component instead of dmc. 