### PR TITLE
bug fix for class deletion

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -1,9 +1,10 @@
 import json
 import os
-import time
 import random
-import plotly.express as px
+import time
+
 import dash_mantine_components as dmc
+import plotly.express as px
 from dash import (
     ALL,
     MATCH,


### PR DESCRIPTION
Bug: When you delete a class, the brush color was still using the color of the deleted class.
Fix: Output to the `current-class-selection` store to use the last (bottom) class by default as the new brush color. 

enhancement: user is now prompted with a new randomized color everytime a class is created. This is to avoid suggesting the same color every time and running into the "color already exists!" error. 
