### PR TITLE
✨ resize image window

### DIFF
--- a/assets/functions.js
+++ b/assets/functions.js
@@ -6,18 +6,3 @@ function changeFilters(js_path, brightness, contrast) {
         element.style.webkitFilter = `brightness(${brightness}%) contrast(${contrast}%)`;
     }
 }
-
-
-
-window.dash_clientside = Object.assign({}, window.dash_clientside, {
-    clientside: {
-        get_container_size: function(url) {
-            let W = window.innerWidth;
-            let H = window.innerHeight;
-            if(W == 0 || H == 0){
-                return dash_clientside.no_update
-            }
-            return {'W': W, 'H':H}
-        },
-    }
-});

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -40,7 +40,6 @@ from utils.plot_utils import (
 def resize_window_event(screen_width, screen_height, annotation_store):
     if not annotation_store["active_img_shape"]:
         raise PreventUpdate
-    print(screen_width, screen_height)
 
     h, w = annotation_store["active_img_shape"]
     image_center_coor = resize_canvas(h, w, screen_height, screen_width)

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -4,16 +4,7 @@ import dash
 import dash_mantine_components as dmc
 import numpy as np
 import plotly.express as px
-from dash import (
-    ALL,
-    Input,
-    Output,
-    Patch,
-    State,
-    callback,
-    clientside_callback,
-    ctx,
-)
+from dash import ALL, Input, Output, Patch, State, callback, clientside_callback, ctx
 from dash.exceptions import PreventUpdate
 from dash_iconify import DashIconify
 

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -1,9 +1,9 @@
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 from dash import dcc, html
+from dash_breakpoints import WindowBreakpoints
 from dash_extensions import EventListener
 from dash_iconify import DashIconify
-from dash_breakpoints import WindowBreakpoints
 
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, KEYBINDS

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -3,6 +3,7 @@ import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_extensions import EventListener
 from dash_iconify import DashIconify
+from dash_breakpoints import WindowBreakpoints
 
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, KEYBINDS
@@ -701,6 +702,9 @@ def drawer_section(children):
                     }
                 ],
                 id="keybind-event-listener",
+            ),
+            WindowBreakpoints(
+                id="window-resize",
             ),
         ]
     )

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -20,7 +20,6 @@ def layout():
         style=COMPONENT_STYLE,
         children=[
             dcc.Store("image-metadata", data={"name": None}),
-            dcc.Store("screen-size"),
             dcc.Location("url"),
             dmc.LoadingOverlay(
                 id="image-viewer-loading",

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ matplotlib
 scipy
 dash-extensions==1.0.1
 dash-bootstrap-components==1.5.0
+dash-breakpoints==0.1.0

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -126,7 +126,7 @@ def get_view_finder_max_min(image_ratio):
         return 250 / image_ratio, 250
 
 
-def resize_canvas(h, w, H, W, figure):
+def resize_canvas(h, w, H, W):
     img_ratio = w / h
     screen_ratio = W / H
     if w <= W and h <= H:
@@ -158,8 +158,18 @@ def resize_canvas(h, w, H, W, figure):
             y1 = h
             y0 = 0
 
-    figure.update_yaxes(range=[y1, y0])
-    figure.update_xaxes(range=[x0, x1])
-
     image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
-    return figure, image_center_coor
+    return image_center_coor
+
+
+def resize_canvas_with_zoom(view, screen_size, fig):
+    H = screen_size["H"]
+    W = screen_size["W"]
+    x0 = view["xaxis_range_0"]
+    y0 = view["yaxis_range_0"]
+    x1 = view["xaxis_range_1"]
+    y1 = view["yaxis_range_1"]
+    y1 = y0 - H / W * (x1 - x0)
+    fig.update_layout(xaxis=dict(range=[x0, x1]), yaxis=dict(range=[y0, y1]))
+    view["yaxis_range_1"] = y1
+    return fig, view


### PR DESCRIPTION
When the app starts, we get initial width and height, which is then used to create the initial figure.
When a resize event happens for whatever reason (full screen, zoom, manual sizing, etc...) `resize_window_event` will trigger, which will then update the figure and viewfinder, and metadata for future callbacks.
The figure is updated in such a way that it will always fit into the screen size.

This takes over #93, which can be deleted. Thanks, @cleaaum, for the nice start 🔥  