### PR TITLE
Window resize using dash_breakpoints

### DIFF
--- a/assets/functions.js
+++ b/assets/functions.js
@@ -9,15 +9,3 @@ function changeFilters(js_path, brightness, contrast) {
 
 
 
-window.dash_clientside = Object.assign({}, window.dash_clientside, {
-    clientside: {
-        get_container_size: function(url) {
-            let W = window.innerWidth;
-            let H = window.innerHeight;
-            if(W == 0 || H == 0){
-                return dash_clientside.no_update
-            }
-            return {'W': W, 'H':H}
-        },
-    }
-});

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -85,7 +85,7 @@ def render_image(
 
         fig["layout"]["shapes"] = all_annotations
         view = annotation_store["view"]
-
+    patched_annotation_store = Patch()
     if screen_width and screen_height:
         if view and ctx.triggered_id != "reset-view":
             # we have a zoom + window size to take into account
@@ -98,8 +98,9 @@ def render_image(
             fig = resize_canvas(
                 tf.shape[0], tf.shape[1], screen_height, screen_width, fig
             )
+            patched_annotation_store["view"] = {}
             view = {}
-    patched_annotation_store = Patch()
+
     patched_annotation_store["active_img_shape"] = list(tf.shape)
     fig_loading_overlay = -1
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -84,22 +84,21 @@ def render_image(
         fig["layout"]["shapes"] = all_annotations
         view = annotation_store["view"]
 
+    patched_annotation_store = Patch()
     if screen_width and screen_height:
         if view:
-            image_center_coor = annotation_store["image_center_coor"]
             # we have a zoom + window size to take into account
             if "xaxis_range_0" in view:
                 fig, view = resize_canvas_with_zoom(
                     view, screen_height, screen_width, fig
                 )
         else:
-            # no zoom level to take into account, window size only
+            # no zoom level to take into account, window size only, save center coordinates
             fig, image_center_coor = resize_canvas(
                 tf.shape[0], tf.shape[1], screen_height, screen_width, fig
             )
+            patched_annotation_store["image_center_coor"] = image_center_coor
 
-    patched_annotation_store = Patch()
-    patched_annotation_store["image_center_coor"] = image_center_coor
     patched_annotation_store["active_img_shape"] = list(tf.shape)
     fig_loading_overlay = -1
 

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -1,8 +1,8 @@
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 from dash import dcc, html
-from dash_extensions import EventListener
 from dash_breakpoints import WindowBreakpoints
+from dash_extensions import EventListener
 from dash_iconify import DashIconify
 
 from components.annotation_class import annotation_class_item

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -2,6 +2,7 @@ import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_extensions import EventListener
+from dash_breakpoints import WindowBreakpoints
 from dash_iconify import DashIconify
 
 from components.annotation_class import annotation_class_item
@@ -701,6 +702,9 @@ def drawer_section(children):
                     }
                 ],
                 id="keybind-event-listener",
+            ),
+            WindowBreakpoints(
+                id="window-resize",
             ),
         ]
     )

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -684,7 +684,6 @@ def drawer_section(children):
                     "visible": True,
                     "view": {},
                     "active_img_shape": [],
-                    "image_center_coor": {},
                 },
             ),
             create_reset_view_affix(),

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -20,7 +20,6 @@ def layout():
         style=COMPONENT_STYLE,
         children=[
             dcc.Store("image-metadata", data={"name": None}),
-            dcc.Store("screen-size"),
             dcc.Location("url"),
             dmc.LoadingOverlay(
                 id="image-viewer-loading",

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ matplotlib
 scipy
 dash-extensions==1.0.1
 dash-bootstrap-components==1.5.0
+dash-breakpoints==0.1.0

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -162,9 +162,8 @@ def resize_canvas(h, w, H, W, figure):
         xaxis=dict(range=[x0, x1]),
         yaxis=dict(range=[y1, y0]),
     )
-    image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
 
-    return figure, image_center_coor
+    return figure
 
 
 def resize_canvas_with_zoom(view, H, W, fig):

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -158,8 +158,20 @@ def resize_canvas(h, w, H, W, figure):
             y1 = h
             y0 = 0
 
-    figure.update_yaxes(range=[y1, y0])
-    figure.update_xaxes(range=[x0, x1])
+    figure.update_layout(
+        xaxis=dict(range=[x0, x1]),
+        yaxis=dict(range=[y1, y0]),
+    )
 
-    image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
-    return figure, image_center_coor
+    return figure, None
+
+
+def resize_canvas_with_zoom(view, H, W, fig):
+    x0 = view["xaxis_range_0"]
+    y0 = view["yaxis_range_0"]
+    x1 = view["xaxis_range_1"]
+    y1 = view["yaxis_range_1"]
+    y1 = y0 - H / W * (x1 - x0)
+    fig.update_layout(xaxis=dict(range=[x0, x1]), yaxis=dict(range=[y0, y1]))
+    view["yaxis_range_1"] = y1
+    return fig, view

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -162,8 +162,9 @@ def resize_canvas(h, w, H, W, figure):
         xaxis=dict(range=[x0, x1]),
         yaxis=dict(range=[y1, y0]),
     )
+    image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
 
-    return figure, None
+    return figure, image_center_coor
 
 
 def resize_canvas_with_zoom(view, H, W, fig):


### PR DESCRIPTION
This PR solves the resizing of the image when the browser is resized. 

There is a small lag between the resizing of the browser and the resizing of the image. This was the way to do it with the least changes as possible. Don't think the lag since users are not constantly resizing. Don't think we can use patch() either since this is updating the whole layout of the graph. 

https://www.loom.com/share/deef0921e99f41b68f417af0db5e26d2?sid=16863182-58ae-4f60-909c-2d312167746a