### PR TITLE
Prevent last class deletion

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -415,26 +415,35 @@ def open_edit_class_modal(
 @callback(
     Output({"type": "delete-annotation-class-modal", "index": MATCH}, "opened"),
     Output({"type": "delete-annotation-class-modal", "index": MATCH}, "title"),
+    Output({"type": "cannot-delete-last-class-modal", "index": MATCH}, "opened"),
     Input({"type": "delete-annotation-class", "index": MATCH}, "n_clicks"),
     Input({"type": "modal-continue-delete-class-btn", "index": MATCH}, "n_clicks"),
     Input({"type": "modal-cancel-delete-class-btn", "index": MATCH}, "n_clicks"),
+    Input({"type": "ok-to-not-delete-last-class-btn", "index": MATCH}, "n_clicks"),
+    State({"type": "cannot-delete-last-class-modal", "index": MATCH}, "opened"),
     State({"type": "delete-annotation-class-modal", "index": MATCH}, "opened"),
     State({"type": "annotation-class-store", "index": MATCH}, "data"),
+    State({"type": "annotation-class-store", "index": ALL}, "data"),
     prevent_initial_call=True,
 )
 def open_delete_class_modal(
     remove_class,
     continue_remove_class_modal,
     cancel_remove_class_modal,
-    opened,
+    ok_not_delete_modal,
+    cannot_delete_modal_opened,
+    delete_modal_opened,
     class_to_delete,
+    all_annotation_classes,
 ):
     """
     This callback opens and closes the modal that allows you to relabel an existing annotation class
-    and triggers the delete_annotation_class() callback.
+    and triggers the delete_annotation_class() callback. It prevents the user from deleting the last class.
     """
+    if len(all_annotation_classes) == 1:
+        return no_update, no_update, not cannot_delete_modal_opened
     modal_title = f"Delete class: {class_to_delete['label']}"
-    return not opened, modal_title
+    return not delete_modal_opened, modal_title, no_update
 
 
 @callback(

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -207,6 +207,32 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                     ),
                 ],
             ),
+            dmc.Modal(
+                id={"type": "cannot-delete-last-class-modal", "index": class_id},
+                children=[
+                    dmc.Center(
+                        dmc.Text(
+                            "You cannot delete the last class",
+                        )
+                    ),
+                    dmc.Space(h=10),
+                    html.Div(
+                        [
+                            dmc.Button(
+                                id={
+                                    "type": "ok-to-not-delete-last-class-btn",
+                                    "index": class_id,
+                                },
+                                children="Ok",
+                            ),
+                        ],
+                        style={
+                            "display": "flex",
+                            "justify-content": "flex-end",
+                        },
+                    ),
+                ],
+            ),
         ],
         style={
             "border": "1px solid #EAECEF",

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -36,18 +36,11 @@ def _control_item(title, title_id, item):
     )
 
 
-def _accordion_item(title, icon, value, children, id, loading=True):
+def _accordion_item(title, icon, value, children, id):
     """
     Returns a customized layout for an accordion item
     """
-    if loading:
-        panel = dmc.LoadingOverlay(
-            dmc.AccordionPanel(children=children, id=id),
-            loaderProps={"size": 0},
-            overlayOpacity=0.4,
-        )
-    else:
-        panel = dmc.AccordionPanel(children=children, id=id)
+    panel = dmc.AccordionPanel(children=children, id=id)
     return dmc.AccordionItem(
         [
             dmc.AccordionControl(
@@ -625,7 +618,6 @@ def layout():
                                 ),
                                 html.Div(id="output-details"),
                             ],
-                            loading=False,
                         ),
                     ],
                 ),


### PR DESCRIPTION
- deletes the ability for a user to delete the last annotation class 
- removes loading overlay on sidebar so it doesn't trigger every time a user types


Didn't spend time on modal styling (assuming this will be done later for all the modals)

<img width="923" alt="Screen Shot 2023-09-22 at 5 38 04 PM" src="https://github.com/mlexchange/mlex_highres_segmentation/assets/56569375/03a70039-8758-45be-b8d1-333e3369f4e1">
