### PR TITLE
Add annotated slice dropdown

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -809,8 +809,11 @@ def open_controls_drawer(n_clicks, is_opened):
     # TODO add input for eraser mode
 )
 def update_current_annotated_slices_values(all_classes, delete_annotations_click):
-    all = []
+    all_annotated_slices = []
     for a in all_classes:
-        all += list(a["annotations"].keys())
-    all = [str(int(slice) + 1) for slice in all]
-    return list(set(all))
+        all_annotated_slices += list(a["annotations"].keys())
+    dropdown_values = [
+        {"value": int(slice) + 1, "label": f"Slice {str(int(slice) + 1)}"}
+        for slice in all_annotated_slices
+    ]
+    return dropdown_values

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -197,7 +197,7 @@ def annotation_mode(
             annotation_store["dragmode"] = "pan"
             styles[trigger] = active
     notification = generate_notification(
-        ANNOT_NOTIFICATION_MSGS[trigger], "indigo", trigger
+        ANNOT_NOTIFICATION_MSGS[trigger], "indigo", ANNOT_ICONS[trigger]
     )
 
     return (
@@ -650,18 +650,19 @@ def export_annotation(n_clicks, all_annotations, global_store):
         mask_data = annotations.get_annotation_mask_as_bytes()
         mask_file = dcc.send_bytes(mask_data, filename="annotation_masks.zip")
 
-        notification_title = "Annotation Exported!"
-        notification_message = "Succesfully exported in .json format."
+        notification_title = ANNOT_NOTIFICATION_MSGS["export"]
+        notification_message = ANNOT_NOTIFICATION_MSGS["export-msg"]
         notification_color = "green"
     else:
         metadata_file, mask_file = no_update, no_update
-        notification_title = "No Annotations to Export!"
-        notification_message = "Please annotate an image before exporting."
+        notification_title = ANNOT_NOTIFICATION_MSGS["export-fail"]
+        notification_message = ANNOT_NOTIFICATION_MSGS["export-fail-msg"]
         notification_color = "red"
+    notification_icon = ANNOT_ICONS["export"]
     notification = generate_notification(
         notification_title,
         notification_color,
-        "export-annotation",
+        notification_icon,
         notification_message,
     )
     return notification, metadata_file, mask_file

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -805,10 +805,9 @@ def open_controls_drawer(n_clicks, is_opened):
 @callback(
     Output("annotated-slices-selector", "data"),
     Input({"type": "annotation-class-store", "index": ALL}, "data"),
-    Input("modal-continue-delete-button", "n_clicks"),
-    # TODO add input for eraser mode
+    # TODO check if erasing an annotation via the erase triggers this CB (it should)
 )
-def update_current_annotated_slices_values(all_classes, delete_annotations_click):
+def update_current_annotated_slices_values(all_classes):
     all_annotated_slices = []
     for a in all_classes:
         all_annotated_slices += list(a["annotations"].keys())

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -30,6 +30,8 @@ from utils.data_utils import (
     DEV_load_exported_json_data,
 )
 
+from utils.plot_utils import generate_notification
+
 # TODO - temporary local file path and user for annotation saving and exporting
 EXPORT_FILE_PATH = "data/exported_annotation_data.json"
 USER_NAME = "user1"
@@ -194,16 +196,10 @@ def annotation_mode(
             patched_figure["layout"]["dragmode"] = "pan"
             annotation_store["dragmode"] = "pan"
             styles[trigger] = active
-
-    notification = dmc.Notification(
-        title=ANNOT_NOTIFICATION_MSGS[trigger],
-        message="",
-        color="indigo",
-        id=f"notification-{random.randint(0, 10000)}",
-        action="show",
-        icon=DashIconify(icon=ANNOT_ICONS[trigger], width=40),
-        styles={"icon": {"height": "50px", "width": "50px"}},
+    notification = generate_notification(
+        ANNOT_NOTIFICATION_MSGS[trigger], "indigo", trigger
     )
+
     return (
         patched_figure,
         styles["closed-freeform"],
@@ -662,14 +658,11 @@ def export_annotation(n_clicks, all_annotations, global_store):
         notification_title = "No Annotations to Export!"
         notification_message = "Please annotate an image before exporting."
         notification_color = "red"
-
-    notification = dmc.Notification(
-        title=notification_title,
-        message=notification_message,
-        color=notification_color,
-        id=f"notification-{random.randint(0, 10000)}",
-        action="show",
-        icon=DashIconify(icon="entypo:export"),
+    notification = generate_notification(
+        notification_title,
+        notification_color,
+        "export-annotation",
+        notification_message,
     )
     return notification, metadata_file, mask_file
 

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -804,6 +804,7 @@ def open_controls_drawer(n_clicks, is_opened):
 
 @callback(
     Output("annotated-slices-selector", "data"),
+    Output("annotated-slices-selector", "disabled"),
     Input({"type": "annotation-class-store", "index": ALL}, "data"),
     # TODO check if erasing an annotation via the erase triggers this CB (it should)
 )
@@ -815,4 +816,5 @@ def update_current_annotated_slices_values(all_classes):
         {"value": int(slice) + 1, "label": f"Slice {str(int(slice) + 1)}"}
         for slice in all_annotated_slices
     ]
-    return dropdown_values
+    disabled = True if len(dropdown_values) == 0 else False
+    return dropdown_values, disabled

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -800,3 +800,14 @@ def open_controls_drawer(n_clicks, is_opened):
             return no_update, {"display": "none"}
         return no_update, {}
     return no_update, no_update
+
+
+@callback(
+    Output("current-annotated-slices", "data"),
+    Input({"type": "annotation-class-store", "index": ALL}, "data"),
+)
+def update_current_annotated_slices_values(all_classes):
+    all = []
+    for a in all_classes:
+        all += list(a["annotations"].keys())
+    return list(set(all))

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -29,7 +29,6 @@ from utils.data_utils import (
     DEV_filter_json_data_by_timestamp,
     DEV_load_exported_json_data,
 )
-
 from utils.plot_utils import generate_notification
 
 # TODO - temporary local file path and user for annotation saving and exporting

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -803,11 +803,14 @@ def open_controls_drawer(n_clicks, is_opened):
 
 
 @callback(
-    Output("current-annotated-slices", "data"),
+    Output("annotated-slices-selector", "data"),
     Input({"type": "annotation-class-store", "index": ALL}, "data"),
+    Input("modal-continue-delete-button", "n_clicks"),
+    # TODO add input for eraser mode
 )
-def update_current_annotated_slices_values(all_classes):
+def update_current_annotated_slices_values(all_classes, delete_annotations_click):
     all = []
     for a in all_classes:
         all += list(a["annotations"].keys())
+    all = [str(int(slice) + 1) for slice in all]
     return list(set(all))

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -68,6 +68,8 @@ def render_image(
     update_slider_value = dash.no_update
     notification = dash.no_update
     if ctx.triggered_id == "annotated-slices-selector":
+        if image_idx == slice_selection:
+            raise PreventUpdate
         image_idx = slice_selection
         reset_slice_selection = None
         update_slider_value = slice_selection

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -65,9 +65,9 @@ def render_image(
     reset_slice_selection = dash.no_update
     update_slider_value = dash.no_update
     if ctx.triggered_id == "annotated-slices-selector":
-        image_idx = int(slice_selection)
+        image_idx = slice_selection
         reset_slice_selection = None
-        update_slider_value = image_idx - 1
+        update_slider_value = slice_selection
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
         tf = get_data_sequence_by_name(project_name)[image_idx]

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -23,9 +23,9 @@ from utils.data_utils import get_data_sequence_by_name, get_data_shape_by_name
 from utils.plot_utils import (
     create_viewfinder,
     downscale_view,
+    generate_notification,
     get_view_finder_max_min,
     resize_canvas,
-    generate_notification,
 )
 
 clientside_callback(

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -42,6 +42,7 @@ clientside_callback(
     Output("image-metadata", "data"),
     Output("annotated-slices-selector", "value"),
     Output("image-selection-slider", "value", allow_duplicate=True),
+    Output("notifications-container", "children", allow_duplicate=True),
     Input("image-selection-slider", "value"),
     Input("annotated-slices-selector", "value"),
     State({"type": "annotation-class-store", "index": ALL}, "data"),
@@ -64,10 +65,21 @@ def render_image(
 ):
     reset_slice_selection = dash.no_update
     update_slider_value = dash.no_update
+    notification = dash.no_update
     if ctx.triggered_id == "annotated-slices-selector":
         image_idx = slice_selection
         reset_slice_selection = None
         update_slider_value = slice_selection
+
+        notification = dmc.Notification(
+            title=f"Jumped to slice {image_idx}",
+            message="",
+            color="indigo",
+            id=f"notification-{random.randint(0, 10000)}",
+            action="show",
+            icon=DashIconify(icon=ANNOT_ICONS["jump-to-slice"], width=40),
+            styles={"icon": {"height": "50px", "width": "50px"}},
+        )
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
         tf = get_data_sequence_by_name(project_name)[image_idx]
@@ -140,6 +152,7 @@ def render_image(
         curr_image_metadata,
         reset_slice_selection,
         update_slider_value,
+        notification,
     )
 
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -25,6 +25,7 @@ from utils.plot_utils import (
     downscale_view,
     get_view_finder_max_min,
     resize_canvas,
+    generate_notification,
 )
 
 clientside_callback(
@@ -70,16 +71,10 @@ def render_image(
         image_idx = slice_selection
         reset_slice_selection = None
         update_slider_value = slice_selection
-
-        notification = dmc.Notification(
-            title=f"Jumped to slice {image_idx}",
-            message="",
-            color="indigo",
-            id=f"notification-{random.randint(0, 10000)}",
-            action="show",
-            icon=DashIconify(icon=ANNOT_ICONS["jump-to-slice"], width=40),
-            styles={"icon": {"height": "50px", "width": "50px"}},
+        notification = generate_notification(
+            f"Jumped to slice {image_idx}", "indigo", "jump-to-slice"
         )
+
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
         tf = get_data_sequence_by_name(project_name)[image_idx]
@@ -190,36 +185,23 @@ def keybind_image_slider(
 
     if pressed_key == KEYBINDS["slice-left"]:
         if current_slice == 1:
-            message = "No more images to the left"
+            title = "No more images to the left"
             new_slice = dash.no_update
-            icon = "pajamas:warning-solid"
+            icon = "no-more-slices"
         else:
             new_slice = current_slice - 1
-            message = f"{ANNOT_NOTIFICATION_MSGS['slice-left']} ({new_slice}) selected"
-            icon = ANNOT_ICONS["slice-left"]
+            title = f"{ANNOT_NOTIFICATION_MSGS['slice-left']} ({new_slice}) selected"
+            icon = "slice-left"
     elif pressed_key == KEYBINDS["slice-right"]:
         if current_slice == max_slice:
-            message = "No more images to the right"
+            title = "No more images to the right"
             new_slice = dash.no_update
-            icon = "pajamas:warning-solid"
+            icon = "no-more-slices"
         else:
             new_slice = current_slice + 1
-            message = f"{ANNOT_NOTIFICATION_MSGS['slice-right']} ({new_slice}) selected"
-            icon = ANNOT_ICONS["slice-right"]
-
-    notification = dmc.Notification(
-        title=message,
-        message="",
-        id=f"notification-{random.randint(0, 10000)}",
-        action="show",
-        icon=DashIconify(icon=icon, width=30),
-        styles={
-            "icon": {
-                "height": "50px",
-                "width": "50px",
-            }
-        },
-    )
+            title = f"{ANNOT_NOTIFICATION_MSGS['slice-right']} ({new_slice}) selected"
+            icon = "slice-right"
+    notification = generate_notification(title, None, icon)
 
     return new_slice, notification
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -40,7 +40,10 @@ clientside_callback(
     Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer-loading", "zIndex", allow_duplicate=True),
     Output("image-metadata", "data"),
+    Output("annotated-slices-selector", "value"),
+    Output("image-selection-slider", "value", allow_duplicate=True),
     Input("image-selection-slider", "value"),
+    Input("annotated-slices-selector", "value"),
     State({"type": "annotation-class-store", "index": ALL}, "data"),
     State("project-name-src", "value"),
     State("annotation-store", "data"),
@@ -51,6 +54,7 @@ clientside_callback(
 )
 def render_image(
     image_idx,
+    slice_selection,
     all_annotation_class_store,
     project_name,
     annotation_store,
@@ -58,6 +62,12 @@ def render_image(
     screen_size,
     current_color,
 ):
+    reset_slice_selection = dash.no_update
+    update_slider_value = dash.no_update
+    if ctx.triggered_id == "annotated-slices-selector":
+        image_idx = int(slice_selection)
+        reset_slice_selection = None
+        update_slider_value = image_idx - 1
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
         tf = get_data_sequence_by_name(project_name)[image_idx]
@@ -128,6 +138,8 @@ def render_image(
         patched_annotation_store,
         fig_loading_overlay,
         curr_image_metadata,
+        reset_slice_selection,
+        update_slider_value,
     )
 
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -72,7 +72,9 @@ def render_image(
         reset_slice_selection = None
         update_slider_value = slice_selection
         notification = generate_notification(
-            f"Jumped to slice {image_idx}", "indigo", "jump-to-slice"
+            f"{ANNOT_NOTIFICATION_MSGS['slice-jump']} {image_idx}",
+            "indigo",
+            ANNOT_ICONS["jump-to-slice"],
         )
 
     if image_idx:
@@ -187,20 +189,20 @@ def keybind_image_slider(
         if current_slice == 1:
             title = "No more images to the left"
             new_slice = dash.no_update
-            icon = "no-more-slices"
+            icon = ANNOT_ICONS["no-more-slices"]
         else:
             new_slice = current_slice - 1
             title = f"{ANNOT_NOTIFICATION_MSGS['slice-left']} ({new_slice}) selected"
-            icon = "slice-left"
+            icon = ANNOT_ICONS["slice-left"]
     elif pressed_key == KEYBINDS["slice-right"]:
         if current_slice == max_slice:
             title = "No more images to the right"
             new_slice = dash.no_update
-            icon = "no-more-slices"
+            icon = ANNOT_ICONS["no-more-slices"]
         else:
             new_slice = current_slice + 1
             title = f"{ANNOT_NOTIFICATION_MSGS['slice-right']} ({new_slice}) selected"
-            icon = "slice-right"
+            icon = ANNOT_ICONS["slice-right"]
     notification = generate_notification(title, None, icon)
 
     return new_slice, notification

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -153,17 +153,9 @@ def layout():
                                 _control_item(
                                     "Annotated Slices",
                                     "current-annotated-slice",
-                                    html.Div(
-                                        [
-                                            dmc.Select(
-                                                id="annotated-slices-selector",
-                                                placeholder="Select a slice to view...",
-                                                # style={"width": "90%"},
-                                            ),
-                                            # dmc.Space(w=10),
-                                            # dmc.Button("Go"),
-                                        ],
-                                        # style={"display": "flex"},
+                                    dmc.Select(
+                                        id="annotated-slices-selector",
+                                        placeholder="Select a slice to view...",
                                     ),
                                 ),
                                 dmc.Space(h=10),

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -156,7 +156,7 @@ def layout():
                                     html.Div(
                                         [
                                             dmc.Select(
-                                                id="current-annotated-slices",
+                                                id="annotated-slices-selector",
                                                 placeholder="Select a slice to view...",
                                                 # style={"width": "90%"},
                                             ),

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -151,7 +151,7 @@ def layout():
                                 ),
                                 dmc.Space(h=25),
                                 _control_item(
-                                    "Annotated Slices",
+                                    "Annotated slices",
                                     "current-annotated-slice",
                                     dmc.Select(
                                         id="annotated-slices-selector",

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -24,12 +24,15 @@ def _control_item(title, title_id, item):
     """
     return dmc.Grid(
         [
-            dmc.Text(
-                title,
-                id=title_id,
-                size="sm",
-                style={"width": "100px", "margin": "auto", "paddingRight": "5px"},
-                align="right",
+            _tooltip(
+                "Jump to your annotated slices",
+                dmc.Text(
+                    title,
+                    id=title_id,
+                    size="sm",
+                    style={"width": "100px", "margin": "auto", "paddingRight": "5px"},
+                    align="right",
+                ),
             ),
             html.Div(item, style={"width": "265px", "margin": "auto"}),
         ]

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -24,15 +24,12 @@ def _control_item(title, title_id, item):
     """
     return dmc.Grid(
         [
-            _tooltip(
-                "Jump to your annotated slices",
-                dmc.Text(
-                    title,
-                    id=title_id,
-                    size="sm",
-                    style={"width": "100px", "margin": "auto", "paddingRight": "5px"},
-                    align="right",
-                ),
+            dmc.Text(
+                title,
+                id=title_id,
+                size="sm",
+                style={"width": "100px", "margin": "auto", "paddingRight": "5px"},
+                align="right",
             ),
             html.Div(item, style={"width": "265px", "margin": "auto"}),
         ]
@@ -154,7 +151,10 @@ def layout():
                                 ),
                                 dmc.Space(h=25),
                                 _control_item(
-                                    "Annotated slices",
+                                    _tooltip(
+                                        "Jump to your annotated slices",
+                                        "Annotated slices",
+                                    ),
                                     "current-annotated-slice",
                                     dmc.Select(
                                         id="annotated-slices-selector",

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -149,6 +149,23 @@ def layout():
                                         )
                                     ],
                                 ),
+                                dmc.Space(h=25),
+                                _control_item(
+                                    "Annotated Slices",
+                                    "current-annotated-slice",
+                                    html.Div(
+                                        [
+                                            dmc.Select(
+                                                id="current-annotated-slices",
+                                                placeholder="Select a slice to view...",
+                                                # style={"width": "90%"},
+                                            ),
+                                            # dmc.Space(w=10),
+                                            # dmc.Button("Go"),
+                                        ],
+                                        # style={"display": "flex"},
+                                    ),
+                                ),
                                 dmc.Space(h=10),
                             ],
                         ),

--- a/constants.py
+++ b/constants.py
@@ -17,6 +17,8 @@ ANNOT_ICONS = {
     "slice-right": "line-md:arrow-right",
     "slice-left": "line-md:arrow-left",
     "jump-to-slice": "mdi:arrow",
+    "export-annotation": "entypo:export",
+    "no-more-slices": "pajamas:warning-solid",
 }
 
 ANNOT_NOTIFICATION_MSGS = {

--- a/constants.py
+++ b/constants.py
@@ -19,6 +19,7 @@ ANNOT_ICONS = {
     "jump-to-slice": "mdi:arrow",
     "export-annotation": "entypo:export",
     "no-more-slices": "pajamas:warning-solid",
+    "export": "entypo:export",
 }
 
 ANNOT_NOTIFICATION_MSGS = {
@@ -29,6 +30,11 @@ ANNOT_NOTIFICATION_MSGS = {
     "pan-and-zoom": "Pan and zoom mode",
     "slice-right": "Next slice",
     "slice-left": "Previous slice",
+    "slice-jump": "Jumped to slice",
+    "export": "Annotation Exported!",
+    "export-msg": "Succesfully exported in .json format.",
+    "export-fail": "No Annotations to Export!",
+    "export-fail-msg": "Please annotate an image before exporting.",
 }
 
 KEY_MODES = {

--- a/constants.py
+++ b/constants.py
@@ -16,6 +16,7 @@ ANNOT_ICONS = {
     "pan-and-zoom": "material-symbols:drag-pan-rounded",
     "slice-right": "line-md:arrow-right",
     "slice-left": "line-md:arrow-left",
+    "jump-to-slice": "mdi:arrow",
 }
 
 ANNOT_NOTIFICATION_MSGS = {

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -1,6 +1,10 @@
 import plotly.express as px
 import plotly.graph_objects as go
 from skimage.transform import resize
+import dash_mantine_components as dmc
+import random
+from dash_iconify import DashIconify
+from constants import ANNOT_ICONS
 
 
 def blank_fig():
@@ -163,3 +167,15 @@ def resize_canvas(h, w, H, W, figure):
 
     image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
     return figure, image_center_coor
+
+
+def generate_notification(title, color, icon, message=""):
+    return dmc.Notification(
+        title=title,
+        message=message,
+        color=color,
+        id=f"notification-{random.randint(0, 10000)}",
+        action="show",
+        icon=DashIconify(icon=ANNOT_ICONS[icon], width=40),
+        styles={"icon": {"height": "50px", "width": "50px"}},
+    )

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -174,8 +174,8 @@ def generate_notification(title, color, icon, message=""):
         title=title,
         message=message,
         color=color,
+        icon=DashIconify(icon=icon, width=40),
         id=f"notification-{random.randint(0, 10000)}",
         action="show",
-        icon=DashIconify(icon=ANNOT_ICONS[icon], width=40),
         styles={"icon": {"height": "50px", "width": "50px"}},
     )

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -1,9 +1,11 @@
+import random
+
+import dash_mantine_components as dmc
 import plotly.express as px
 import plotly.graph_objects as go
-from skimage.transform import resize
-import dash_mantine_components as dmc
-import random
 from dash_iconify import DashIconify
+from skimage.transform import resize
+
 from constants import ANNOT_ICONS
 
 


### PR DESCRIPTION
This PR adds a dropdown with the currently annotated slices. When a slice has annotations on it, this dropdown gets populated so the user can easily find which slices were annotated.

Implementation notes:
- When a user selects a slice to jump to, the dropdown value clears after it has been selected. This is to avoid confusion when a user goes to a different slice, there is no mismatch between the current slice and the slice in the dropdown. 
- This dropdown gets updated every time an annotation is drawn, when a class is deleted, when all annotations are deleted on a slice (and when a specific annotation is deleted via the eraser).
- May need to rework/rephrase the UI


<img width="411" alt="Screen Shot 2023-09-25 at 11 31 21 AM" src="https://github.com/mlexchange/mlex_highres_segmentation/assets/56569375/9b87284a-4e29-459f-89bd-fbddd33d34d4">

Closes #122 
