### PR TITLE
Annot exporting improved

### DIFF
--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -165,42 +165,28 @@ class ShapeConversion:
     @classmethod
     def ellipse_to_array(self, svg_data, image_shape, mask_class):
         image_height, image_width = image_shape
-        x0 = svg_data["x0"]
-        y0 = svg_data["y0"]
-        x1 = svg_data["x1"]
-        y1 = svg_data["y1"]
 
-        # Calculate the radius of the circle (r)
-        r = math.sqrt((x1 - x0) ** 2 + (y1 - y0) ** 2)
+        cx = (svg_data["x0"] + svg_data["x1"]) / 2
+        cy = (svg_data["y0"] + svg_data["y1"]) / 2
 
-        # Calculate the radius in x-direction (r_radius)
-        r_radius = abs(x1 - x0)
+        # Radii calculations
+        r_radius = abs(svg_data["x0"] - svg_data["x1"]) / 2  # Horizontal radius
+        c_radius = abs(svg_data["y0"] - svg_data["y1"]) / 2  # Vertical radius
 
-        # Calculate the radius in y-direction (c_radius)
-        c_radius = abs(y1 - y0)
-
-        # Center of the circle (cx, cy)
-        cx = x0
-        cy = y0
-
-        # Adjust center coordinates to fit within the image bounds
+        # Clip center coordinates to image bounds
         cx = max(min(int(cx), image_width - 1), 0)
         cy = max(min(int(cy), image_height - 1), 0)
 
-        r, cx, cy, r_radius, c_radius = int(r), cx, cy, int(r_radius), int(c_radius)
-
-        # Scale the radius if needed to fit within the image bounds
-        max_radius = min(cx, cy, image_width - cx, image_height - cy)
-        r_radius = min(r_radius, max_radius)
-        c_radius = min(c_radius, max_radius)
-
-        # Create the image and draw the circle
+        # Create mask and draw ellipse
         mask = np.zeros((image_height, image_width), dtype=np.uint8)
-        rr, cc = draw.ellipse(cy, cx, r_radius, c_radius)
+        rr, cc = draw.ellipse(
+            cy, cx, c_radius, r_radius
+        )  # Vertical radius first, then horizontal
 
         # Ensure indices are within valid image bounds
         rr = np.clip(rr, 0, image_height - 1)
         cc = np.clip(cc, 0, image_width - 1)
+
         mask[rr, cc] = mask_class
         return mask
 

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -160,31 +160,6 @@ class Annotations:
                 "y1": annotation["y1"],
             }
 
-    # TODO: Outdated?
-    def _set_annotation_line_width(self, annotation):
-        """
-        This function sets the line width of the annotation.
-        """
-        self.annotation_line_width = annotation["line"]["width"]
-
-    # TODO: Outdated?
-    def _set_annotation_class(self, annotation):
-        """
-        This function sets the class of the annotation.
-        """
-        self.annotation_class = 99
-        for item in self.annotation_store["label_mapping"]:
-            if item["color"] == annotation["line"]["color"]:
-                self.annotation_class = item["id"]
-
-    # TODO: Outdated?
-    def _set_annotation_image_shape(self, image_idx):
-        """
-        This function sets the the size of the image slice
-        """
-        # TODO: Assuming all images in the slice are the same shape
-        self.annotation_image_shape = self.annotation_store["image_shapes"][0]
-
 
 class ShapeConversion:
     @classmethod

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -173,10 +173,6 @@ class ShapeConversion:
         r_radius = abs(svg_data["x0"] - svg_data["x1"]) / 2  # Horizontal radius
         c_radius = abs(svg_data["y0"] - svg_data["y1"]) / 2  # Vertical radius
 
-        # Clip center coordinates to image bounds
-        cx = max(min(int(cx), image_width - 1), 0)
-        cy = max(min(int(cy), image_height - 1), 0)
-
         # Create mask and draw ellipse
         mask = np.zeros((image_height, image_width), dtype=np.uint8)
         rr, cc = draw.ellipse(


### PR DESCRIPTION
*New*
- fixed ellipse annotation mask creation


*Checked existing features*
- overlapping works fine as is, the annotations on "top" will be on top (so long the order of the annotations in the storage remains as is (eg. new stuff is appended to the existing list at the end))
- Out-of-bounds works too with existing code 
  - annotations entirely created outside are not included
  - annotations that only have "parts" going outside are correctly cut out