### PR TITLE
Nersc deployment adaptations (Auth, Environment variables)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pri-venv
 data/
 
 env
+*env/
 *.hdf5
 *.db
 
@@ -23,4 +24,3 @@ env
 *.tif
 
 .env
-config.py

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ and
 pip install -r requirements-dev.txt
 ```
 
-2. Configure a connection to the Tiled server via a `.env` file with the following environment variables:
+2. Set environment variables via a `.env` file to configure a connection to the Tiled server, differentiate between local testing and development mode and set a user and password for basic autherization:
 
 ```
-TILED_URI='https://mlex-segmentation.als.lbl.gov'
+TILED_URI='https://tiled-seg.als.lbl.gov'
 TILED_API_KEY=<key-provided-on-request>
 MODE='dev'
+USER_NAME=<to-be-specified-per-deployment>
+USER_PASSWORD=<to-be-specified-per-deployment>
 ```
 
 3. Start a local server: 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements-dev.txt
 
 ```
 TILED_URI='https://mlex-segmentation.als.lbl.gov'
-API_KEY=<key-provided-on-request>
+TILED_API_KEY=<key-provided-on-request>
 MODE='dev'
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ python app.py
 Developers may also choose to set up a local Tiled server with access to minimal datasets (eg. in the case that the remote server is down).
 
 To start local tiled connection:
-1. Add `SERVE_LOCALLY=True` flag to `.env` file (or to your environmental variables)
+1. Add `TILED_DEPLOYMENT_LOC="Local"` flag to `.env` file (or to your environmental variables)
 2. Start the app once, which will create `data/` directory and download 2 sample projects with 2 images each.
-3. Open a second terminal and run `tiled serve directory --public data`.
+3. Open a second terminal and run `/tiled_serve_dir.sh`.
 
 The app will now connect to the local tiled server.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ pip install -r requirements-dev.txt
 ```
 TILED_URI='https://tiled-seg.als.lbl.gov'
 TILED_API_KEY=<key-provided-on-request>
+DASH_DEPLOYMENT_LOC='Local'
 MODE='dev'
-USER_NAME=<to-be-specified-per-deployment>
-USER_PASSWORD=<to-be-specified-per-deployment>
 ```
 
 3. Start a local server: 
@@ -49,6 +48,15 @@ To start local tiled connection:
 3. Open a second terminal and run `tiled serve directory --public data`.
 
 The app will now connect to the local tiled server.
+
+### Deployment elsewhere
+
+For deployment elsewhere add a user name and password to the environment file and remove `DASH_DEPLOYMENT_LOC = "Local"`. This protect access to the application with basic authentication:
+
+```
+USER_NAME=<to-be-specified-per-deployment>
+USER_PASSWORD=<to-be-specified-per-deployment>
+```
 
 # Copyright
 MLExchange Copyright (c) 2023, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy). All rights reserved.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import os
+
+import dash_auth
 import dash_mantine_components as dmc
 from dash import Dash, dcc
 
@@ -7,8 +10,15 @@ from callbacks.segmentation import *
 from components.control_bar import layout as control_bar_layout
 from components.image_viewer import layout as image_viewer_layout
 
+USER_NAME = os.getenv("USER_NAME")
+USER_PASSWORD = os.getenv("USER_PASSWORD")
+
+VALID_USER_NAME_PASSWORD_PAIRS = {USER_NAME: USER_PASSWORD}
+
 app = Dash(__name__)
 server = app.server
+
+auth = dash_auth.BasicAuth(app, VALID_USER_NAME_PASSWORD_PAIRS)
 
 app.layout = dmc.MantineProvider(
     theme={"colorScheme": "light"},

--- a/app.py
+++ b/app.py
@@ -18,7 +18,12 @@ VALID_USER_NAME_PASSWORD_PAIRS = {USER_NAME: USER_PASSWORD}
 app = Dash(__name__)
 server = app.server
 
-auth = dash_auth.BasicAuth(app, VALID_USER_NAME_PASSWORD_PAIRS)
+# Set single user name password pair if deployment isn't
+auth = (
+    dash_auth.BasicAuth(app, VALID_USER_NAME_PASSWORD_PAIRS)
+    if os.getenv("DASH_DEPLOYMENT_LOC", "") != "Local"
+    else None
+)
 
 app.layout = dmc.MantineProvider(
     theme={"colorScheme": "light"},

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -31,8 +31,8 @@ from utils.data_utils import (
 )
 
 # TODO - temporary local file path and user for annotation saving and exporting
-EXPORT_FILE_PATH = "data/exported_annotation_data.json"
 USER_NAME = "user1"
+EXPORT_FILE_PATH = os.getenv("EXPORT_FILE_PATH", "data/exported_annotation_data.json")
 
 # Create an empty file if it doesn't exist
 if not os.path.exists(EXPORT_FILE_PATH):

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -31,8 +31,8 @@ from utils.data_utils import (
 )
 
 # TODO - temporary local file path and user for annotation saving and exporting
-USER_NAME = "user1"
 EXPORT_FILE_PATH = os.getenv("EXPORT_FILE_PATH", "data/exported_annotation_data.json")
+USER_NAME = os.getenv("USER_NAME", "user1")
 
 # Create an empty file if it doesn't exist
 if not os.path.exists(EXPORT_FILE_PATH):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       TILED_API_KEY: '${TILED_API_KEY}'
     volumes:
       - ./app.py:/app/app.py
+      - ./constants.py:/app/constants.py
       - ./callbacks:/app/callbacks
       - ./components:/app/components
       - ./utils:/app/utils

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     command: 'gunicorn -b 0.0.0.0:8075 --reload app:server'
     environment:
       TILED_URI: '${TILED_URI}'
-      API_KEY: '${API_KEY}'
+      TILED_API_KEY: '${TILED_API_KEY}'
     volumes:
       - ./app.py:/app/app.py
       - ./callbacks:/app/callbacks

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ matplotlib
 scipy
 dash-extensions==1.0.1
 dash-bootstrap-components==1.5.0
+dash_auth==2.0.0

--- a/tiled_serve_dir.sh
+++ b/tiled_serve_dir.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source .env
+export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
+tiled serve directory data

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -126,7 +126,7 @@ def save_annotations_data(global_store, all_annotations, project_name):
 load_dotenv()
 
 TILED_URI = os.getenv("TILED_URI")
-API_KEY = os.getenv("API_KEY")
+TILED_API_KEY = os.getenv("TILED_API_KEY")
 
 if os.getenv("SERVE_LOCALLY", False):
     print("To run a Tiled server locally run `tiled serve directory --public data`.")
@@ -136,7 +136,7 @@ if os.getenv("SERVE_LOCALLY", False):
     client = from_uri("http://localhost:8000")
     data = client
 else:
-    client = from_uri(TILED_URI, api_key=API_KEY, timeout=httpx.Timeout(30.0))
+    client = from_uri(TILED_URI, api_key=TILED_API_KEY, timeout=httpx.Timeout(30.0))
     data = client["reconstruction"]
 
 

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -128,8 +128,8 @@ load_dotenv()
 TILED_URI = os.getenv("TILED_URI")
 TILED_API_KEY = os.getenv("TILED_API_KEY")
 
-if os.getenv("SERVE_LOCALLY", False):
-    print("To run a Tiled server locally run `tiled serve directory --public data`.")
+if os.getenv("TILED_DEPLOYMENT_LOC", "") == "Local":
+    print("To run a Tiled server locally run the bash script `./tiled_serve_dir.sh`.")
     print("This requires to additionally install the server components of Tiled with:")
     print('`pip install "tiled[server]"`')
     DEV_download_google_sample_data()


### PR DESCRIPTION
This PR groups some minor changes in relation to the deployment on Nersc. Most importantly it adds the basic auth wrapper, for now with a single username-password pair.

Additionally the following minor changes are included:

* Rename `API_KEY` to `TILED_API_KEY` to prepare for adding other keys (e.g. to Splash ML)
* Update the `TILED_URI` to `https://tiled-seg.als.lbl.gov` in `README.md`
* Make it possible for `EXPORT_FILE_PATH` to be an environment variable
* Add missing volume mount for `constants.py` in `docker-compose.yml`
* Ignore differently named Python environments `*env/`