### PR TITLE
🐛 remove focus from slider

### DIFF
--- a/assets/functions.js
+++ b/assets/functions.js
@@ -17,7 +17,28 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             if(W == 0 || H == 0){
                 return dash_clientside.no_update
             }
+            // keep `remove_focus()` here or add it to a separate callback if necessary
+            // so that it executes ONCE at when the app loads
+            remove_focus();
             return {'W': W, 'H':H}
-        },
+        }
+
     }
 });
+
+/**
+ * Removes focus from the "image-selection-slider" container and its children.
+ * This is necessary to prevent the slider from moving by "two steps" when
+ * the user clicks on the slider, and then immediately uses the arrow keys.
+ */
+function remove_focus() {
+    const sliderContainer = document.getElementById('image-selection-slider');
+    
+    sliderContainer.addEventListener('focus', () => {
+        sliderContainer.blur();
+    });
+    
+    sliderContainer.addEventListener('blur', () => {
+        sliderContainer.blur();
+    });
+}


### PR DESCRIPTION
Adds an event listener to the slice slider which removes the focus after interaction, this way it won't be triggered twice in the rare case described in the bug