### PR TITLE
small fixes for JS console errors

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -509,7 +509,7 @@ def edit_annotation_class(
     class_color_identifier = {
         "width": "25px",
         "height": "25px",
-        "background-color": new_color + "50",
+        "backgroundColor": new_color + "50",
         "margin": "5px",
         "borderRadius": "3px",
         "border": f"2px solid {new_color}",
@@ -640,7 +640,6 @@ def clear_annotation_class(
 clientside_callback(
     """
     function dash_filters_clientside(brightness, contrast) {
-    console.log(brightness, contrast)
         js_path = "#image-viewer > div.js-plotly-plot > div > div > svg:nth-child(1)"
         changeFilters(js_path, brightness, contrast)
         return ""

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -70,7 +70,7 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                         style={
                             "width": "25px",
                             "height": "25px",
-                            "background-color": class_color_transparent,
+                            "backgroundColor": class_color_transparent,
                             "margin": "5px",
                             "borderRadius": "3px",
                             "border": f"2px solid {class_color}",
@@ -90,8 +90,8 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                 ],
                 style={
                     "display": "flex",
-                    "justify-content": "flex-row",
-                    "align-items": "center",
+                    "justifyContent": "flex-row",
+                    "alignItems": "center",
                     "color": "#9EA4AB",
                 },
             ),
@@ -105,8 +105,8 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                 ],
                 style={
                     "display": "flex",
-                    "justify-content": "flex-row",
-                    "align-items": "center",
+                    "justifyContent": "flex-row",
+                    "alignItems": "center",
                     "padding": "3px",
                 },
             ),
@@ -150,8 +150,8 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                         ],
                         style={
                             "display": "flex",
-                            "justify-content": "flex-row",
-                            "align-items": "center",
+                            "justifyContent": "flex-row",
+                            "alignItems": "center",
                         },
                     ),
                     html.Div(
@@ -166,7 +166,7 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                         ],
                         style={
                             "display": "flex",
-                            "justify-content": "flex-end",
+                            "justifyContent": "flex-end",
                         },
                     ),
                 ],
@@ -202,7 +202,7 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                         ],
                         style={
                             "display": "flex",
-                            "justify-content": "flex-end",
+                            "justifyContent": "flex-end",
                         },
                     ),
                 ],
@@ -228,7 +228,7 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
                         ],
                         style={
                             "display": "flex",
-                            "justify-content": "flex-end",
+                            "justifyContent": "flex-end",
                         },
                     ),
                 ],

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -297,10 +297,10 @@ def layout():
                                             ],
                                             className="flex-row",
                                             style={
-                                                "justify-content": "space-evenly",
+                                                "justifyContent": "space-evenly",
                                                 "padding": "2.5px",
                                                 "border": "1px solid #EAECEF",
-                                                "border-radius": "5px",
+                                                "borderRadius": "5px",
                                             },
                                         ),
                                         dmc.Space(w=10),
@@ -369,10 +369,10 @@ def layout():
                                             className="flex-row",
                                             style={
                                                 "width": "301px",
-                                                "justify-content": "space-evenly",
+                                                "justifyContent": "space-evenly",
                                                 "padding": "2.5px",
                                                 "border": "1px solid #EAECEF",
-                                                "border-radius": "5px",
+                                                "borderRadius": "5px",
                                             },
                                         ),
                                     ]
@@ -464,8 +464,8 @@ def layout():
                                             ],
                                             style={
                                                 "display": "flex",
-                                                "justify-content": "flex-row",
-                                                "align-items": "center",
+                                                "justifyContent": "flex-row",
+                                                "alignItems": "center",
                                             },
                                         ),
                                         html.Div(
@@ -477,7 +477,7 @@ def layout():
                                             ],
                                             style={
                                                 "display": "flex",
-                                                "justify-content": "flex-end",
+                                                "justifyContent": "flex-end",
                                             },
                                         ),
                                     ],

--- a/components/image_viewer.py
+++ b/components/image_viewer.py
@@ -37,7 +37,7 @@ def layout():
                             "width": "100vw",
                             "height": "100vh",
                             "position": "fixed",
-                            "z-index": 1,
+                            "zIndex": 1,
                         },
                     ),
                 ],

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -197,7 +197,7 @@ def generate_notification_bg_icon_col(title, color, icon, message=""):
             "icon": {
                 "height": "50px",
                 "width": "50px",
-                "background-color": f"{color} !important",
+                "backgroundColor": f"{color} !important",
             }
         },
     )


### PR DESCRIPTION
These styling typos were causing a lot of errors in the JS console making it hard to debug. 
Inline styles in Dash have to be camelCase and not kebab-case (although both will work).