### PR TITLE
bugfix + adding loading overlay

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -185,9 +185,6 @@ def annotation_mode(
     if generate_modal_opened or any(edit_modal_opened):
         # user is going to type on this page (on a modal) and we don't want to trigger this callback using keys
         raise PreventUpdate
-    # if the image is loading stop the callback when keybinds are pressed
-    if figure_overlay_z_index != -1:
-        raise PreventUpdate
 
     trigger = ctx.triggered_id
     pressed_key = (

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -97,10 +97,12 @@ def render_image(
     update_slider_value = dash.no_update
     notification = dash.no_update
     if ctx.triggered_id == "annotated-slices-selector":
-        if image_idx == slice_selection:
-            raise PreventUpdate
-        image_idx = slice_selection
         reset_slice_selection = None
+        if image_idx == slice_selection:
+            ret_values = [dash.no_update] * 8
+            ret_values[5] = reset_slice_selection
+            return ret_values
+        image_idx = slice_selection
         update_slider_value = slice_selection
         notification = generate_notification(
             f"{ANNOT_NOTIFICATION_MSGS['slice-jump']} {image_idx}",
@@ -309,13 +311,14 @@ def update_viewfinder(relayout_data, annotation_store):
 
 clientside_callback(
     """
-    function EnableImageLoadingOverlay(zIndexSlider,zIndexToggle) {
+    function EnableImageLoadingOverlay(zIndexSlider,zIndexToggle,zIndexSliceSelector) {
         return 9999;
     }
     """,
     Output("image-viewer-loading", "zIndex"),
     Input("image-selection-slider", "value"),
     Input("show-result-overlay-toggle", "checked"),
+    Input("annotated-slices-selector", "value"),
 )
 
 

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -60,7 +60,6 @@ def hide_show_segmentation_overlay(toggle_seg_result, opacity):
     Output("image-viewer", "figure"),
     Output("image-viewfinder", "figure"),
     Output("annotation-store", "data", allow_duplicate=True),
-    Output("image-viewer-loading", "zIndex", allow_duplicate=True),
     Output("image-metadata", "data"),
     Output("annotated-slices-selector", "value"),
     Output("image-selection-slider", "value", allow_duplicate=True),
@@ -99,8 +98,8 @@ def render_image(
     if ctx.triggered_id == "annotated-slices-selector":
         reset_slice_selection = None
         if image_idx == slice_selection:
-            ret_values = [dash.no_update] * 8
-            ret_values[5] = reset_slice_selection
+            ret_values = [dash.no_update] * 7
+            ret_values[4] = reset_slice_selection
             return ret_values
         image_idx = slice_selection
         update_slider_value = slice_selection
@@ -169,7 +168,6 @@ def render_image(
     patched_annotation_store = Patch()
     patched_annotation_store["image_center_coor"] = image_center_coor
     patched_annotation_store["active_img_shape"] = list(tf.shape)
-    fig_loading_overlay = -1
 
     image_ratio = round(tf.shape[1] / tf.shape[0], 2)
     patched_annotation_store["image_ratio"] = image_ratio
@@ -190,7 +188,6 @@ def render_image(
         fig,
         fig_viewfinder,
         patched_annotation_store,
-        fig_loading_overlay,
         curr_image_metadata,
         reset_slice_selection,
         update_slider_value,


### PR DESCRIPTION
BugFix:
- annoation toolbar is disabled after using the slice selector 
- slice selector was not getting cleared after selecting same slice user is currently on

Added:
- loading overlay when a user jumps to a slice using the dropdown 
