### PR TITLE
Configurable tiled URIs for input data, masks and segmented results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# The URI of a container in a Tiled server with data to be segmented
+# Replace <your-value-here> with the URI for such a container. 
+# Examples are:
+# the 'reconstruction' container of the public server, containing tomography reconstructions: 
+#   'https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction'
+# the root container of a local server: 
+#   'http://localhost:8000/'
+# the 'processed' container of a server running in a docker container: 
+#   'http://tiled:8000/api/v1/metadata/processed'
+DATA_TILED_URI=<your-value-here>
+# API key for accessing the Tiled server and container from DATA_TILED_URI
+# Replace <your-value-here> with your API key
+DATA_TILED_API_KEY=<your-value-here>
+
+# The URI of a container in a Tiled server where we can store mask information
+# Replace <your-value-here> with the URL of your Tiled server. 
+# You will need write-access to this container.
+MASK_TILED_URI=<your-value-here>
+# API key for accessing the Tiled server and container from MASK_TILED_URI
+# Replace <your-value-here> with your API key 
+MASK_TILED_API_KEY=<api-key>
+
+# The URI of a Tiled server where segmentation results can be retrieved
+# The Tiled server will most likely be the same as the one used for storing masks
+# This top-level URI is not used directly. 
+# Instead we expect ML jobs to return one or more URIs pointing to specific results
+# Replace <your-value-here> with the URL of your Tiled server. 
+SEG_TILED_URI=<your-value-here>
+# API key for accessing the Tiled server from SEG_TILED_URI
+# Replace <your-value-here> with your API key
+SEG_TILED_API_KEY=<api-key>
+
+# Development environment variables, to be removed in upcoming versions
+TILED_DEPLOYMENT_LOC='Local'
+DASH_DEPLOYMENT_LOC='Local'
+EXPORT_FILE_PATH='data/exported_annotations.json'
+MODE='dev'
+
+# Basic authentication for segmentation application when deploying on a publicly accessible server
+USER_NAME=<to-be-specified-per-deployment>
+USER_PASSWORD=<to-be-specified-per-deployment>

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ pip install -r requirements-dev.txt
 2. Set environment variables via a `.env` file to configure a connection to the Tiled server, differentiate between local testing and development mode and set a user and password for basic autherization:
 
 ```
-TILED_URI='https://tiled-seg.als.lbl.gov'
-TILED_API_KEY=<key-provided-on-request>
+DATA_TILED_URI='https://tiled-seg.als.lbl.gov'
+DATA_TILED_API_KEY=<key-provided-on-request>
 DASH_DEPLOYMENT_LOC='Local'
 MODE='dev'
 ```

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ python app.py
 
 ### Local tiled connection
 
-Developers may also choose to set up a local Tiled server with access to minimal datasets (eg. in the case that the remote server is down).
+For local testing of just the annotation functionality, developers may also choose to set up a local Tiled server with access to minimal datasets (eg. in the case that the remote server is down).
 
-To start local tiled connection:
-1. Add `TILED_DEPLOYMENT_LOC="Local"` flag to `.env` file (or to your environmental variables)
-2. Start the app once, which will create `data/` directory and download 2 sample projects with 2 images each.
-3. Open a second terminal and run `/tiled_serve_dir.sh`.
+To download some sample data and serve it with a local Tiled serve
+1. Additionally install the Tiled server components with `pip install "tiled[server]"`.
+2. Set the input Tiled URI to localhost, e.g. set `DATA_TILED_URI`, to `http://localhost:8000/` within the `.env` file (or within your environmental variables), and use the result of a key generator (e.g. with `python3 -c "import secrets; print(secrets.token_hex(32))"`) for the key entry `DATA_TILED_API_KEY`
+2. Run the script `python3 utils/download_sample_data.py`. This will create a `data/` directory and download 2 sample projects with 2 images each.
+3. Run `/tiled_serve_dir.sh`.
 
-The app will now connect to the local tiled server.
+Starting the app will now connect to the local tiled server instead.
 
 ### Deployment elsewhere
 

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -1,5 +1,4 @@
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
 import dash_mantine_components as dmc
 from dash import dcc, html
 from dash_extensions import EventListener

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     build: .
     command: 'gunicorn -b 0.0.0.0:8075 --reload app:server'
     environment:
-      TILED_URI: '${TILED_URI}'
-      TILED_API_KEY: '${TILED_API_KEY}'
+      DATA_TILED_URI: '${DATA_TILED_URI}'
+      DATA_TILED_API_KEY: '${DATA_TILED_API_KEY}'
     volumes:
       - ./app.py:/app/app.py
       - ./constants.py:/app/constants.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tifffile==2023.4.12
 tzdata==2023.3
 Werkzeug==2.2.3
 zipp==3.15.0
-tiled[client]==0.1.0a105
+tiled[client]==0.1.0a114
 gunicorn==20.1.0
 requests==2.26.0
 python-dotenv

--- a/tiled_serve_dir.sh
+++ b/tiled_serve_dir.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 source .env
-export TILED_SINGLE_USER_API_KEY=$TILED_API_KEY
+export TILED_SINGLE_USER_API_KEY=$DATA_TILED_API_KEY
 tiled serve directory data

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -117,10 +117,13 @@ def get_data_sequence_by_name(project_name):
         return project_client
     # If project_name points to a container
     elif isinstance(project_client, Container):
-        # Check if the specs gives us information about which sub-container to access
+        # Check if the specs give us information about which sub-container to access
         specs = project_client.specs
         if any(spec.name == "NXtomoproc" for spec in specs):
-            # Placeholder for
+            # Example for how to access data if the project container corresponds to a
+            # nexus-file following the NXtomoproc definition
+            # TODO: This assumes that a validator has checked the file on ingestion
+            # Otherwise we should first test if the path holds data
             return project_client["/NXtomoproc/entry/data/data"]
         # Enter the container and return first element
         # if it represents an array

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -161,15 +161,22 @@ def get_data_project_names():
 def get_data_sequence_by_name(project_name):
     """
     Data sequences may be given directly inside the main client container,
-    but can also be additionally encapsulated in a folder.
+    but can also be additionally encapsulated in a folder, multiple container or in a .nxs file.
+    We make use of specs to figure out the path to the 3d data.
     """
     project_client = data[project_name]
-    # If the project directly points to an array
+    # If the project directly points to an array, directly return it
     if isinstance(project_client, ArrayClient):
         return project_client
     # If project_name points to a container
     elif isinstance(project_client, Container):
+        # Check if the specs gives us information about which sub-container to access
+        specs = project_client.specs
+        if any(spec.name == "NXtomoproc" for spec in specs):
+            # Placeholder for
+            return project_client["/NXtomoproc/entry/data/data"]
         # Enter the container and return first element
+        # if it represents an array
         if len(list(project_client)) == 1:
             sequence_client = project_client.values()[0]
             if isinstance(sequence_client, ArrayClient):

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -15,18 +15,8 @@ load_dotenv()
 
 DATA_TILED_URI = os.getenv("DATA_TILED_URI")
 DATA_TILED_API_KEY = os.getenv("DATA_TILED_API_KEY")
-LOCAL_MODE = os.getenv("TILED_DEPLOYMENT_LOC")
 
-if os.getenv("TILED_DEPLOYMENT_LOC", "") == "Local":
-    print("To run a Tiled server locally run the bash script `./tiled_serve_dir.sh`.")
-    print("This requires to additionally install the server components of Tiled with:")
-    print('`pip install "tiled[server]"`')
-    DEV_download_google_sample_data()
-    data = from_uri("http://localhost:8000")
-else:
-    data = from_uri(
-        DATA_TILED_URI, api_key=DATA_TILED_API_KEY, timeout=httpx.Timeout(30.0)
-    )
+data = from_uri(DATA_TILED_URI, api_key=DATA_TILED_API_KEY, timeout=httpx.Timeout(30.0))
 
 
 def get_data_project_names():

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -150,22 +150,12 @@ def get_data_project_names():
     Get available project names from the main Tiled container,
     filtered by types that can be processed (Container and ArrayClient)
     """
-    if LOCAL_MODE == "Local":
-        project_names = [
-            project
-            for project in list(data)
-            if isinstance(data[project], (Container, ArrayClient))
-        ]
-        return project_names
-    else:
-        # TODO: remove hard-coded names when caching is implemented
-        return [
-            "rec20191210_111800_lobster-claw_acid_vs_not_2_bin2",
-            "rec20190524_085542_clay_testZMQ_8bit",
-            "rec20221222_085501_looking_from_above_spiralUP_CounterClockwise_endPointAtDoor",
-            "seg-rec20190524_085542_clay_testZMQ_8bit",
-            "RECON_20180227_110041_bamboo_wet_bent_cropped",
-        ]
+    project_names = [
+        project
+        for project in list(data)
+        if isinstance(data[project], (Container, ArrayClient))
+    ]
+    return project_names
 
 
 def get_data_sequence_by_name(project_name):

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -11,69 +11,6 @@ from tiled.client.container import Container
 from utils.annotations import Annotations
 
 
-def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):
-    """
-    This function is used to load the exported json, which was saved in a local file.
-    User name is used to filter the data by user.
-    Project name is used to filter the data by project.
-    It is sorted by timestamp with the latest timestamp first.
-
-    TODO: this function will be replaced with a database query in the future.
-    """
-    DATA_JSON = []
-
-    with open(file_path, "r") as f:
-        for line in f:
-            if line.strip():
-                json_data = json.loads(line)
-                json_data["data"] = json.loads(json_data["data"])
-                DATA_JSON.append(json_data)
-
-    data = [
-        data
-        for data in DATA_JSON
-        if data["user"] == USER_NAME and data["source"] == PROJECT_NAME
-    ]
-    if data:
-        data = sorted(data, key=lambda x: x["time"], reverse=True)
-
-    return data
-
-
-def DEV_filter_json_data_by_timestamp(data, timestamp):
-    return [data for data in data if data["time"] == timestamp]
-
-
-def save_annotations_data(global_store, all_annotations, project_name):
-    """
-    Transforms annotations data to a pixelated mask and outputs to
-    the Tiled server
-
-    # TODO: Save data to Tiled server after transformation
-    """
-    annotations = Annotations(all_annotations, global_store)
-    annotations.create_annotation_mask(sparse=True)  # TODO: Check sparse status
-
-    # Get metadata and annotation data
-    metadata = annotations.get_annotations()
-    mask = annotations.get_annotation_mask()
-
-    # Get raw images associated with each annotated slice
-    img_idx = list(metadata.keys())
-    img = data[project_name]
-    raw = []
-    for idx in img_idx:
-        ar = img[int(idx)]
-        raw.append(ar)
-    try:
-        raw = np.stack(raw)
-        mask = np.stack(mask)
-    except ValueError:
-        return "No annotations to process."
-
-    return
-
-
 load_dotenv()
 
 DATA_TILED_URI = os.getenv("DATA_TILED_URI")
@@ -153,3 +90,66 @@ def get_annotated_segmented_results(json_file_path="exported_annotation_data.jso
                 json_data["data"] = json.loads(json_data["data"])
                 annotated_slices = list(json_data["data"][0]["annotations"].keys())
     return annotated_slices
+
+
+def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):
+    """
+    This function is used to load the exported json, which was saved in a local file.
+    User name is used to filter the data by user.
+    Project name is used to filter the data by project.
+    It is sorted by timestamp with the latest timestamp first.
+
+    TODO: this function will be replaced with a database query in the future.
+    """
+    DATA_JSON = []
+
+    with open(file_path, "r") as f:
+        for line in f:
+            if line.strip():
+                json_data = json.loads(line)
+                json_data["data"] = json.loads(json_data["data"])
+                DATA_JSON.append(json_data)
+
+    data = [
+        data
+        for data in DATA_JSON
+        if data["user"] == USER_NAME and data["source"] == PROJECT_NAME
+    ]
+    if data:
+        data = sorted(data, key=lambda x: x["time"], reverse=True)
+
+    return data
+
+
+def DEV_filter_json_data_by_timestamp(data, timestamp):
+    return [data for data in data if data["time"] == timestamp]
+
+
+def save_annotations_data(global_store, all_annotations, project_name):
+    """
+    Transforms annotations data to a pixelated mask and outputs to
+    the Tiled server
+
+    # TODO: Save data to Tiled server after transformation
+    """
+    annotations = Annotations(all_annotations, global_store)
+    annotations.create_annotation_mask(sparse=True)  # TODO: Check sparse status
+
+    # Get metadata and annotation data
+    metadata = annotations.get_annotations()
+    mask = annotations.get_annotation_mask()
+
+    # Get raw images associated with each annotated slice
+    img_idx = list(metadata.keys())
+    img = data[project_name]
+    raw = []
+    for idx in img_idx:
+        ar = img[int(idx)]
+        raw.append(ar)
+    try:
+        raw = np.stack(raw)
+        mask = np.stack(mask)
+    except ValueError:
+        return "No annotations to process."
+
+    return

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -129,8 +129,8 @@ def save_annotations_data(global_store, all_annotations, project_name):
 
 load_dotenv()
 
-TILED_URI = os.getenv("TILED_URI")
-TILED_API_KEY = os.getenv("TILED_API_KEY")
+DATA_TILED_URI = os.getenv("DATA_TILED_URI")
+DATA_TILED_API_KEY = os.getenv("DATA_TILED_API_KEY")
 LOCAL_MODE = os.getenv("TILED_DEPLOYMENT_LOC")
 
 if os.getenv("TILED_DEPLOYMENT_LOC", "") == "Local":
@@ -138,11 +138,11 @@ if os.getenv("TILED_DEPLOYMENT_LOC", "") == "Local":
     print("This requires to additionally install the server components of Tiled with:")
     print('`pip install "tiled[server]"`')
     DEV_download_google_sample_data()
-    client = from_uri("http://localhost:8000")
-    data = client
+    data = from_uri("http://localhost:8000")
 else:
-    client = from_uri(TILED_URI, api_key=TILED_API_KEY, timeout=httpx.Timeout(30.0))
-    data = client["reconstruction"]
+    data = from_uri(
+        DATA_TILED_URI, api_key=DATA_TILED_API_KEY, timeout=httpx.Timeout(30.0)
+    )
 
 
 def get_data_project_names():

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -3,65 +3,12 @@ import os
 
 import httpx
 import numpy as np
-import requests
 from dotenv import load_dotenv
 from tiled.client import from_uri
 from tiled.client.array import ArrayClient
 from tiled.client.container import Container
 
 from utils.annotations import Annotations
-
-
-def DEV_download_google_sample_data():
-    """
-    Download sample project images to data/ folder, this only happens once,
-    after that the download is skipped if the data exists.
-    """
-
-    def download_file(url, destination):
-        response = requests.get(url, stream=True)
-        response.raise_for_status()
-        with open(destination, "wb") as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    file.write(chunk)
-
-    sample_data_links = {
-        "check_handedness": [
-            "https://drive.google.com/u/0/uc?id=1l42VFZcmVOITL3-eqCKVX_u3PDc7Vkw7&export=download",
-            "https://drive.google.com/u/0/uc?id=1Glio8R-ur65iESK8cvjg7uUHXWnY1odx&export=download",
-        ],
-        "clay_testZMQ": [
-            "https://drive.google.com/uc?export=download&id=1GCkK65bBAU79M6grHDKeTUJaeHl-bNgT",  # slice 200
-            "https://drive.google.com/uc?export=download&id=1Jp1TEdl2tkerqIaDIR4CCL1tKDM3Tc5G",  # slice 201
-        ],
-        "seg-clay_testZMQ": [
-            "https://drive.google.com/uc?export=download&id=15MwMHHLR6jWSE8uV2iS3AqkDQWnP-R3d",  # slice 200
-            "https://drive.google.com/uc?export=download&id=1XyIzbKXBud8kmUrSxPnFFmTfUMfI9wQo",  # slice 201        ],
-        ],
-    }
-    base_directory = "data"
-
-    print("Downloading sample data...")
-    if not os.path.exists(base_directory):
-        os.makedirs(base_directory)
-
-    for project, urls in sample_data_links.items():
-        project_directory = os.path.join(base_directory, project)
-        if not os.path.exists(project_directory):
-            os.makedirs(project_directory)
-
-        for i, url in enumerate(urls):
-            destination = os.path.join(project_directory, f"{i}.tiff")
-
-            if os.path.exists(destination):
-                print(f"File {destination} already exists. Skipping download.")
-                continue
-
-            download_file(url, destination)
-            print(f"Downloaded {destination}")
-
-    print("All files downloaded successfully.")
 
 
 def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):

--- a/utils/download_sample_data.py
+++ b/utils/download_sample_data.py
@@ -1,0 +1,59 @@
+import requests
+import os
+
+
+def DEV_download_google_sample_data():
+    """
+    Download sample project images to data/ folder, this only happens once,
+    after that the download is skipped if the data exists.
+    """
+
+    def download_file(url, destination):
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        with open(destination, "wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    file.write(chunk)
+
+    sample_data_links = {
+        "check_handedness": [
+            "https://drive.google.com/u/0/uc?id=1l42VFZcmVOITL3-eqCKVX_u3PDc7Vkw7&export=download",
+            "https://drive.google.com/u/0/uc?id=1Glio8R-ur65iESK8cvjg7uUHXWnY1odx&export=download",
+        ],
+        "clay_testZMQ": [
+            "https://drive.google.com/uc?export=download&id=1GCkK65bBAU79M6grHDKeTUJaeHl-bNgT",  # slice 200
+            "https://drive.google.com/uc?export=download&id=1Jp1TEdl2tkerqIaDIR4CCL1tKDM3Tc5G",  # slice 201
+        ],
+        "seg-clay_testZMQ": [
+            "https://drive.google.com/uc?export=download&id=15MwMHHLR6jWSE8uV2iS3AqkDQWnP-R3d",  # slice 200
+            "https://drive.google.com/uc?export=download&id=1XyIzbKXBud8kmUrSxPnFFmTfUMfI9wQo",  # slice 201        ],
+        ],
+    }
+    base_directory = "data"
+
+    print("Downloading sample data...")
+    if not os.path.exists(base_directory):
+        os.makedirs(base_directory)
+
+    for project, urls in sample_data_links.items():
+        project_directory = os.path.join(base_directory, project)
+        if not os.path.exists(project_directory):
+            os.makedirs(project_directory)
+
+        for i, url in enumerate(urls):
+            destination = os.path.join(project_directory, f"{i}.tiff")
+
+            if os.path.exists(destination):
+                print(f"File {destination} already exists. Skipping download.")
+                continue
+
+            download_file(url, destination)
+            print(f"Downloaded {destination}")
+
+    print("All files downloaded successfully.")
+
+
+if __name__ == "__main__":
+    DEV_download_google_sample_data()
+    print("Sample data downloaded successfully.")


### PR DESCRIPTION
This PR addresses #161 by introducing separate environment variables to configure (potentially distinct) connections to Tiled servers for input data, mask information and segmented results.

This includes refactoring some of the code around downloading sample data and setting up a local Tiled server for development purposes, to avoid the use of a hard-coded URI that is depended on an environment variable (e.g. `TILED_DEPLOYMENT_LOC`="Local" is no longer used).