### PR TITLE
:sparkles: Added a button to refresh dataset list when tiled server i…

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -26,7 +26,7 @@ from dash_iconify import DashIconify
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEY_MODES, KEYBINDS
 from utils.annotations import Annotations
-from utils.data_utils import data_tools
+from utils.data_utils import tiled_dataset
 from utils.plot_utils import generate_notification, generate_notification_bg_icon_col
 
 # TODO - temporary local file path and user for annotation saving and exporting
@@ -757,7 +757,7 @@ def populate_load_annotations_dropdown_menu_options(modal_opened, image_src):
     if not modal_opened:
         raise PreventUpdate
 
-    data = data_tools.DEV_load_exported_json_data(EXPORT_FILE_PATH, USER_NAME, image_src)
+    data = tiled_dataset.DEV_load_exported_json_data(EXPORT_FILE_PATH, USER_NAME, image_src)
     if not data:
         return "No annotations found for the selected data source."
 
@@ -801,8 +801,8 @@ def load_and_apply_selected_annotations(selected_annotation, image_src, img_idx)
     )["index"]
 
     # TODO : when quering from the server, load (data) for user, source, time
-    data = data_tools.DEV_load_exported_json_data(EXPORT_FILE_PATH, USER_NAME, image_src)
-    data = data_tools.DEV_filter_json_data_by_timestamp(data, str(selected_annotation_timestamp))
+    data = tiled_dataset.DEV_load_exported_json_data(EXPORT_FILE_PATH, USER_NAME, image_src)
+    data = tiled_dataset.DEV_filter_json_data_by_timestamp(data, str(selected_annotation_timestamp))
     data = data[0]["data"]
 
     annotations = []
@@ -846,9 +846,9 @@ def populate_classification_results(
     image_src, refresh_tiled, toggle, dropdown_enabled, slider_enabled
 ):
     if refresh_tiled:
-        data_tools.refresh_data()
+        tiled_dataset.refresh_data()
     
-    data_options = [ item for item in data_tools.get_data_project_names() if "seg" not in item] 
+    data_options = [ item for item in tiled_dataset.get_data_project_names() if "seg" not in item] 
     results = []
     value = None
     checked = False
@@ -865,7 +865,7 @@ def populate_classification_results(
     else:
         results = [
             item
-            for item in data_tools.get_data_project_names()
+            for item in tiled_dataset.get_data_project_names()
             if ("seg" in item and image_src in item)
         ]
         if results:

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -21,11 +21,7 @@ from dash_iconify import DashIconify
 from plotly.subplots import make_subplots
 
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEYBINDS
-from utils.data_utils import (
-    get_annotated_segmented_results,
-    get_data_sequence_by_name,
-    get_data_shape_by_name,
-)
+from utils.data_utils import data_tools
 from utils.plot_utils import (
     create_viewfinder,
     downscale_view,
@@ -117,7 +113,7 @@ def render_image(
 
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
-        tf = get_data_sequence_by_name(project_name)[image_idx]
+        tf = data_tools.get_data_sequence_by_name(project_name)[image_idx]
         if toggle_seg_result:
             # if toggle is true and overlay exists already (2 images in data) this will
             # be handled in hide_show_segmentation_overlay callback
@@ -126,8 +122,8 @@ def render_image(
                 and ctx.triggered_id == "show-result-overlay-toggle"
             ):
                 return [dash.no_update] * 7 + ["hidden"]
-            if str(image_idx + 1) in get_annotated_segmented_results():
-                result = get_data_sequence_by_name(seg_result_selection)[image_idx]
+            if str(image_idx + 1) in data_tools.get_annotated_segmented_results():
+                result = data_tools.get_data_sequence_by_name(seg_result_selection)[image_idx]
             else:
                 result = None
     else:
@@ -490,7 +486,7 @@ def update_slider_values(project_name, annotation_store):
     "update_selection_and_image" callback which will update image and slider selection component.
     """
     # Retrieve data shape if project_name is valid and points to a 3d array
-    data_shape = get_data_shape_by_name(project_name) if project_name else None
+    data_shape = data_tools.get_data_shape_by_name(project_name) if project_name else None
     disable_slider = data_shape is None
     if not disable_slider:
         # TODO: Assuming that all slices have the same image shape

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -21,7 +21,7 @@ from dash_iconify import DashIconify
 from plotly.subplots import make_subplots
 
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEYBINDS
-from utils.data_utils import data_tools
+from utils.data_utils import tiled_dataset
 from utils.plot_utils import (
     create_viewfinder,
     downscale_view,
@@ -113,7 +113,7 @@ def render_image(
 
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
-        tf = data_tools.get_data_sequence_by_name(project_name)[image_idx]
+        tf = tiled_dataset.get_data_sequence_by_name(project_name)[image_idx]
         if toggle_seg_result:
             # if toggle is true and overlay exists already (2 images in data) this will
             # be handled in hide_show_segmentation_overlay callback
@@ -122,8 +122,8 @@ def render_image(
                 and ctx.triggered_id == "show-result-overlay-toggle"
             ):
                 return [dash.no_update] * 7 + ["hidden"]
-            if str(image_idx + 1) in data_tools.get_annotated_segmented_results():
-                result = data_tools.get_data_sequence_by_name(seg_result_selection)[image_idx]
+            if str(image_idx + 1) in tiled_dataset.get_annotated_segmented_results():
+                result = tiled_dataset.get_data_sequence_by_name(seg_result_selection)[image_idx]
             else:
                 result = None
     else:
@@ -486,7 +486,7 @@ def update_slider_values(project_name, annotation_store):
     "update_selection_and_image" callback which will update image and slider selection component.
     """
     # Retrieve data shape if project_name is valid and points to a 3d array
-    data_shape = data_tools.get_data_shape_by_name(project_name) if project_name else None
+    data_shape = tiled_dataset.get_data_shape_by_name(project_name) if project_name else None
     disable_slider = data_shape is None
     if not disable_slider:
         # TODO: Assuming that all slices have the same image shape

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -8,7 +8,7 @@ import requests
 from dash import ALL, Input, Output, State, callback, no_update
 from dash.exceptions import PreventUpdate
 
-from utils.data_utils import data_tools
+from utils.data_utils import tiled_dataset
 from utils.annotations import Annotations
 
 MODE = os.getenv("MODE", "")
@@ -86,7 +86,7 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
             )
         else:
 
-            data_tools.save_annotations_data(
+            tiled_dataset.save_annotations_data(
                 global_store, all_annotations, project_name
             )
             job_submitted = requests.post(

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -8,9 +8,8 @@ import requests
 from dash import ALL, Input, Output, State, callback, no_update
 from dash.exceptions import PreventUpdate
 
-from utils import data_utils
+from utils.data_utils import data_tools
 from utils.annotations import Annotations
-from utils.data_utils import get_data_sequence_by_name
 
 MODE = os.getenv("MODE", "")
 
@@ -86,7 +85,8 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
                 job_uid,
             )
         else:
-            data_utils.save_annotations_data(
+
+            data_tools.save_annotations_data(
                 global_store, all_annotations, project_name
             )
             job_submitted = requests.post(

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -6,7 +6,7 @@ from dash_iconify import DashIconify
 
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, KEYBINDS
-from utils.data_utils import data_tools
+from utils.data_utils import tiled_dataset
 
 
 def _tooltip(text, children):
@@ -62,7 +62,7 @@ def layout():
     Returns the layout for the control panel in the app UI
     """
     DATA_OPTIONS = [
-        item for item in data_tools.get_data_project_names() if "seg" not in item
+        item for item in tiled_dataset.get_data_project_names() if "seg" not in item
     ]
     return drawer_section(
         dmc.Stack(

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -6,7 +6,7 @@ from dash_iconify import DashIconify
 
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, KEYBINDS
-from utils import data_utils
+from utils.data_utils import data_tools
 
 
 def _tooltip(text, children):
@@ -62,7 +62,7 @@ def layout():
     Returns the layout for the control panel in the app UI
     """
     DATA_OPTIONS = [
-        item for item in data_utils.get_data_project_names() if "seg" not in item
+        item for item in data_tools.get_data_project_names() if "seg" not in item
     ]
     return drawer_section(
         dmc.Stack(
@@ -76,16 +76,37 @@ def layout():
                             "majesticons:data-line",
                             "data-select",
                             id="data-selection-controls",
-                            children=[
+                            children=[ 
                                 dmc.Space(h=5),
                                 _control_item(
                                     "Dataset",
                                     "image-selector",
-                                    dmc.Select(
-                                        id="project-name-src",
-                                        data=DATA_OPTIONS,
-                                        value=DATA_OPTIONS[0] if DATA_OPTIONS else None,
-                                        placeholder="Select an image to view...",
+                                    dmc.Grid(
+                                        [
+                                            dmc.Select(
+                                                id="project-name-src",
+                                                data=DATA_OPTIONS,
+                                                value=DATA_OPTIONS[0] if DATA_OPTIONS else None,
+                                                placeholder="Select an image to view...",
+                                            ),
+                                            dmc.ActionIcon(
+                                                _tooltip(
+                                                    "Refresh dataset",
+                                                    children=[
+                                                        DashIconify(
+                                                            icon="mdi:refresh-circle",
+                                                            width=20,
+                                                        ),
+                                                    ],
+                                                ),
+                                                size="xs",
+                                                variant="subtle",
+                                                id="refresh-tiled",
+                                                n_clicks=0,
+                                                style={"margin": "auto"},
+                                            ),
+                                        ],
+                                        style={"margin": "0px"},
                                     ),
                                 ),
                                 dmc.Space(h=25),

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -16,130 +16,146 @@ load_dotenv()
 DATA_TILED_URI = os.getenv("DATA_TILED_URI")
 DATA_TILED_API_KEY = os.getenv("DATA_TILED_API_KEY")
 
-data = from_uri(DATA_TILED_URI, api_key=DATA_TILED_API_KEY, timeout=httpx.Timeout(30.0))
+
+class DataUtils:
+    def __init__(self, data_tiled_uri=DATA_TILED_URI, data_tiled_api_key=DATA_TILED_API_KEY):
+        self.data_tiled_uri = data_tiled_uri
+        self.data_tiled_api_key = data_tiled_api_key
+        self.data = from_uri(self.data_tiled_uri, api_key=self.data_tiled_api_key, timeout=httpx.Timeout(30.0))
+    
+    
+    def refresh_data(self):
+        self.data = from_uri(self.data_tiled_uri, api_key=self.data_tiled_api_key, timeout=httpx.Timeout(30.0))
 
 
-def get_data_project_names():
-    """
-    Get available project names from the main Tiled container,
-    filtered by types that can be processed (Container and ArrayClient)
-    """
-    project_names = [
-        project
-        for project in list(data)
-        if isinstance(data[project], (Container, ArrayClient))
-    ]
-    return project_names
+    def get_data_project_names(self):
+        """
+        Get available project names from the main Tiled container,
+        filtered by types that can be processed (Container and ArrayClient)
+        """
+        project_names = [
+            project
+            for project in list(self.data)
+            if isinstance(self.data[project], (Container, ArrayClient))
+        ]
+        return project_names
 
 
-def get_data_sequence_by_name(project_name):
-    """
-    Data sequences may be given directly inside the main client container,
-    but can also be additionally encapsulated in a folder, multiple container or in a .nxs file.
-    We make use of specs to figure out the path to the 3d data.
-    """
-    project_client = data[project_name]
-    # If the project directly points to an array, directly return it
-    if isinstance(project_client, ArrayClient):
-        return project_client
-    # If project_name points to a container
-    elif isinstance(project_client, Container):
-        # Check if the specs give us information about which sub-container to access
-        specs = project_client.specs
-        if any(spec.name == "NXtomoproc" for spec in specs):
-            # Example for how to access data if the project container corresponds to a
-            # nexus-file following the NXtomoproc definition
-            # TODO: This assumes that a validator has checked the file on ingestion
-            # Otherwise we should first test if the path holds data
-            return project_client["entry/data/data"]
-        # Enter the container and return first element
-        # if it represents an array
-        if len(list(project_client)) == 1:
-            sequence_client = project_client.values()[0]
-            if isinstance(sequence_client, ArrayClient):
-                return sequence_client
-    return None
+    def get_data_sequence_by_name(self, project_name):
+        """
+        Data sequences may be given directly inside the main client container,
+        but can also be additionally encapsulated in a folder, multiple container or in a .nxs file.
+        We make use of specs to figure out the path to the 3d data.
+        """
+        project_client = self.data[project_name]
+        # If the project directly points to an array, directly return it
+        if isinstance(project_client, ArrayClient):
+            return project_client
+        # If project_name points to a container
+        elif isinstance(project_client, Container):
+            # Check if the specs give us information about which sub-container to access
+            specs = project_client.specs
+            if any(spec.name == "NXtomoproc" for spec in specs):
+                # Example for how to access data if the project container corresponds to a
+                # nexus-file following the NXtomoproc definition
+                # TODO: This assumes that a validator has checked the file on ingestion
+                # Otherwise we should first test if the path holds data
+                return project_client["entry/data/data"]
+            # Enter the container and return first element
+            # if it represents an array
+            if len(list(project_client)) == 1:
+                sequence_client = project_client.values()[0]
+                if isinstance(sequence_client, ArrayClient):
+                    return sequence_client
+        return None
 
 
-def get_data_shape_by_name(project_name):
-    """
-    Retrieve shape of the data
-    """
-    project_container = get_data_sequence_by_name(project_name)
-    if project_container:
-        return project_container.shape
-    return None
+    def get_data_shape_by_name(self, project_name):
+        """
+        Retrieve shape of the data
+        """
+        project_container = self.get_data_sequence_by_name(project_name)
+        if project_container:
+            return project_container.shape
+        return None
+
+    
+    @staticmethod
+    def get_annotated_segmented_results(json_file_path="exported_annotation_data.json"):
+        annotated_slices = []
+        with open(json_file_path, "r") as f:
+            for line in f:
+                if line.strip():
+                    json_data = json.loads(line)
+                    json_data["data"] = json.loads(json_data["data"])
+                    annotated_slices = list(json_data["data"][0]["annotations"].keys())
+        return annotated_slices
+
+    
+    @staticmethod
+    def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):
+        """
+        This function is used to load the exported json, which was saved in a local file.
+        User name is used to filter the data by user.
+        Project name is used to filter the data by project.
+        It is sorted by timestamp with the latest timestamp first.
+
+        TODO: this function will be replaced with a database query in the future.
+        """
+        DATA_JSON = []
+
+        with open(file_path, "r") as f:
+            for line in f:
+                if line.strip():
+                    json_data = json.loads(line)
+                    json_data["data"] = json.loads(json_data["data"])
+                    DATA_JSON.append(json_data)
+
+        data = [
+            data
+            for data in DATA_JSON
+            if data["user"] == USER_NAME and data["source"] == PROJECT_NAME
+        ]
+        if data:
+            data = sorted(data, key=lambda x: x["time"], reverse=True)
+
+        return data
+
+    
+    @staticmethod
+    def DEV_filter_json_data_by_timestamp(data, timestamp):
+        return [data for data in data if data["time"] == timestamp]
 
 
-def get_annotated_segmented_results(json_file_path="exported_annotation_data.json"):
-    annotated_slices = []
-    with open(json_file_path, "r") as f:
-        for line in f:
-            if line.strip():
-                json_data = json.loads(line)
-                json_data["data"] = json.loads(json_data["data"])
-                annotated_slices = list(json_data["data"][0]["annotations"].keys())
-    return annotated_slices
+    def save_annotations_data(self, global_store, all_annotations, project_name):
+        """
+        Transforms annotations data to a pixelated mask and outputs to
+        the Tiled server
+
+        # TODO: Save data to Tiled server after transformation
+        """
+        annotations = Annotations(all_annotations, global_store)
+        annotations.create_annotation_mask(sparse=True)  # TODO: Check sparse status
+
+        # Get metadata and annotation data
+        metadata = annotations.get_annotations()
+        mask = annotations.get_annotation_mask()
+
+        # Get raw images associated with each annotated slice
+        img_idx = list(metadata.keys())
+        img = self.data[project_name]
+        raw = []
+        for idx in img_idx:
+            ar = img[int(idx)]
+            raw.append(ar)
+        try:
+            raw = np.stack(raw)
+            mask = np.stack(mask)
+        except ValueError:
+            return "No annotations to process."
+
+        return
 
 
-def DEV_load_exported_json_data(file_path, USER_NAME, PROJECT_NAME):
-    """
-    This function is used to load the exported json, which was saved in a local file.
-    User name is used to filter the data by user.
-    Project name is used to filter the data by project.
-    It is sorted by timestamp with the latest timestamp first.
+data_tools = DataUtils()
 
-    TODO: this function will be replaced with a database query in the future.
-    """
-    DATA_JSON = []
-
-    with open(file_path, "r") as f:
-        for line in f:
-            if line.strip():
-                json_data = json.loads(line)
-                json_data["data"] = json.loads(json_data["data"])
-                DATA_JSON.append(json_data)
-
-    data = [
-        data
-        for data in DATA_JSON
-        if data["user"] == USER_NAME and data["source"] == PROJECT_NAME
-    ]
-    if data:
-        data = sorted(data, key=lambda x: x["time"], reverse=True)
-
-    return data
-
-
-def DEV_filter_json_data_by_timestamp(data, timestamp):
-    return [data for data in data if data["time"] == timestamp]
-
-
-def save_annotations_data(global_store, all_annotations, project_name):
-    """
-    Transforms annotations data to a pixelated mask and outputs to
-    the Tiled server
-
-    # TODO: Save data to Tiled server after transformation
-    """
-    annotations = Annotations(all_annotations, global_store)
-    annotations.create_annotation_mask(sparse=True)  # TODO: Check sparse status
-
-    # Get metadata and annotation data
-    metadata = annotations.get_annotations()
-    mask = annotations.get_annotation_mask()
-
-    # Get raw images associated with each annotated slice
-    img_idx = list(metadata.keys())
-    img = data[project_name]
-    raw = []
-    for idx in img_idx:
-        ar = img[int(idx)]
-        raw.append(ar)
-    try:
-        raw = np.stack(raw)
-        mask = np.stack(mask)
-    except ValueError:
-        return "No annotations to process."
-
-    return

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -17,7 +17,7 @@ DATA_TILED_URI = os.getenv("DATA_TILED_URI")
 DATA_TILED_API_KEY = os.getenv("DATA_TILED_API_KEY")
 
 
-class DataUtils:
+class TiledDataLoader:
     def __init__(self, data_tiled_uri=DATA_TILED_URI, data_tiled_api_key=DATA_TILED_API_KEY):
         self.data_tiled_uri = data_tiled_uri
         self.data_tiled_api_key = data_tiled_api_key
@@ -157,5 +157,5 @@ class DataUtils:
         return
 
 
-data_tools = DataUtils()
+tiled_dataset = TiledDataLoader()
 


### PR DESCRIPTION
Changelog:
1. encapsulated data util functions as a class object, which is shared across scripts after instantiated.
2. added a refresh button next to the dataset dropdown to update the available datasets after tiled server is updated (re-indexed).

Note: removing a dataset from tiled will trigger missing data error if the dropdown selection was the one that is removed. Adding new dataset to tiled server should be fine.   