### PR TITLE
Save pixelated masks to Tiled

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+.git
+.gitignore

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -26,7 +26,7 @@ from dash_iconify import DashIconify
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEY_MODES, KEYBINDS
 from utils.annotations import Annotations
-from utils.data_utils import tiled_dataset
+from utils.data_utils import tiled_datasets, tiled_masks, tiled_results
 from utils.plot_utils import generate_notification, generate_notification_bg_icon_col
 
 # TODO - temporary local file path and user for annotation saving and exporting
@@ -758,7 +758,7 @@ def populate_load_annotations_dropdown_menu_options(modal_opened, image_src):
     if not modal_opened:
         raise PreventUpdate
 
-    data = tiled_dataset.DEV_load_exported_json_data(
+    data = tiled_masks.DEV_load_exported_json_data(
         EXPORT_FILE_PATH, USER_NAME, image_src
     )
     if not data:
@@ -804,10 +804,10 @@ def load_and_apply_selected_annotations(selected_annotation, image_src, img_idx)
     )["index"]
 
     # TODO : when quering from the server, load (data) for user, source, time
-    data = tiled_dataset.DEV_load_exported_json_data(
+    data = tiled_masks.DEV_load_exported_json_data(
         EXPORT_FILE_PATH, USER_NAME, image_src
     )
-    data = tiled_dataset.DEV_filter_json_data_by_timestamp(
+    data = tiled_masks.DEV_filter_json_data_by_timestamp(
         data, str(selected_annotation_timestamp)
     )
     data = data[0]["data"]
@@ -853,10 +853,10 @@ def populate_classification_results(
     image_src, refresh_tiled, toggle, dropdown_enabled, slider_enabled
 ):
     if refresh_tiled:
-        tiled_dataset.refresh_data_client()
+        tiled_datasets.refresh_data_client()
 
     data_options = [
-        item for item in tiled_dataset.get_data_project_names() if "seg" not in item
+        item for item in tiled_datasets.get_data_project_names() if "seg" not in item
     ]
     results = []
     value = None
@@ -872,9 +872,10 @@ def populate_classification_results(
         disabled_toggle = False
         disabled_slider = slider_enabled
     else:
+        # TODO: Match by mask uid instead of image_src
         results = [
             item
-            for item in tiled_dataset.get_data_project_names()
+            for item in tiled_results.get_data_project_names()
             if ("seg" in item and image_src in item)
         ]
         if results:

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -853,7 +853,7 @@ def populate_classification_results(
     image_src, refresh_tiled, toggle, dropdown_enabled, slider_enabled
 ):
     if refresh_tiled:
-        tiled_dataset.refresh_data()
+        tiled_dataset.refresh_data_client()
 
     data_options = [
         item for item in tiled_dataset.get_data_project_names() if "seg" not in item

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -332,6 +332,10 @@ def open_annotation_class_modal(
             disable_class_creation = True
             error_msg.append("Label Already in Use!")
             error_msg.append(html.Br())
+        if new_label == "Unlabeled":
+            disable_class_creation = True
+            error_msg.append("Label name cannot be 'Unlabeled'")
+            error_msg.append(html.Br())
         if new_color in current_colors:
             disable_class_creation = True
             error_msg.append("Color Already in use!")

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -16,7 +16,7 @@ from dash import (
 from dash.exceptions import PreventUpdate
 
 from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEYBINDS
-from utils.data_utils import tiled_dataset
+from utils.data_utils import tiled_datasets, tiled_masks, tiled_results
 from utils.plot_utils import (
     create_viewfinder,
     downscale_view,
@@ -108,7 +108,7 @@ def render_image(
 
     if image_idx:
         image_idx -= 1  # slider starts at 1, so subtract 1 to get the correct index
-        tf = tiled_dataset.get_data_sequence_by_name(project_name)[image_idx]
+        tf = tiled_datasets.get_data_sequence_by_name(project_name)[image_idx]
         if toggle_seg_result:
             # if toggle is true and overlay exists already (2 images in data) this will
             # be handled in hide_show_segmentation_overlay callback
@@ -117,8 +117,8 @@ def render_image(
                 and ctx.triggered_id == "show-result-overlay-toggle"
             ):
                 return [dash.no_update] * 7 + ["hidden"]
-            if str(image_idx + 1) in tiled_dataset.get_annotated_segmented_results():
-                result = tiled_dataset.get_data_sequence_by_name(seg_result_selection)[
+            if str(image_idx + 1) in tiled_masks.get_annotated_segmented_results():
+                result = tiled_results.get_data_sequence_by_name(seg_result_selection)[
                     image_idx
                 ]
             else:
@@ -485,7 +485,7 @@ def update_slider_values(project_name, annotation_store):
     """
     # Retrieve data shape if project_name is valid and points to a 3d array
     data_shape = (
-        tiled_dataset.get_data_shape_by_name(project_name) if project_name else None
+        tiled_datasets.get_data_shape_by_name(project_name) if project_name else None
     )
     disable_slider = data_shape is None
     if not disable_slider:

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -118,9 +118,12 @@ def render_image(
                 and ctx.triggered_id == "show-result-overlay-toggle"
             ):
                 return [dash.no_update] * 7 + ["hidden"]
-            if str(image_idx + 1) in tiled_masks.get_annotated_segmented_results():
+            annotation_indices = tiled_masks.get_annotated_segmented_results()
+            if str(image_idx + 1) in annotation_indices:
+                # Will not return an error since we already checked if image_idx+1 is in the list
+                mapped_index = annotation_indices.index(str(image_idx + 1))
                 result = tiled_results.get_data_sequence_by_name(seg_result_selection)[
-                    image_idx
+                    mapped_index
                 ]
             else:
                 result = None

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -21,6 +21,7 @@ from utils.plot_utils import (
     create_viewfinder,
     downscale_view,
     generate_notification,
+    generate_segmentation_colormap,
     get_view_finder_max_min,
     resize_canvas,
 )
@@ -127,20 +128,14 @@ def render_image(
         tf = np.zeros((500, 500))
     fig = px.imshow(tf, binary_string=True)
     if toggle_seg_result and result is not None:
-        unique_segmentation_values = np.unique(result)
-        normalized_range = np.linspace(
-            0, 1, len(unique_segmentation_values)
-        )  # heatmap requires a normalized range
-        color_list = (
-            px.colors.qualitative.Plotly
-        )  # TODO placeholder - replace with user defined classess
-        colorscale = [
-            [normalized_range[i], color_list[i % len(color_list)]]
-            for i in range(len(unique_segmentation_values))
-        ]
+        colorscale, max_class_id = generate_segmentation_colormap(
+            all_annotation_class_store
+        )
         fig.add_trace(
             go.Heatmap(
                 z=result,
+                zmin=-0.5,
+                zmax=max_class_id + 0.5,
                 colorscale=colorscale,
                 showscale=False,
             )

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -74,19 +74,19 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
     """
     if n_clicks:
         if MODE == "dev":
-            tiled_masks.save_annotations_data(
+            mask_uri = tiled_masks.save_annotations_data(
                 global_store, all_annotations, project_name
             )
             job_uid = str(uuid.uuid4())
             return (
                 dmc.Text(
-                    f"Workflow has been succesfully submitted with uid: {job_uid}",
+                    f"Workflow has been succesfully submitted with uid: {job_uid} and mask uri: {mask_uri}",
                     size="sm",
                 ),
                 job_uid,
             )
         else:
-            tiled_masks.save_annotations_data(
+            mask_uri = tiled_masks.save_annotations_data(
                 global_store, all_annotations, project_name
             )
             job_submitted = requests.post(

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -7,7 +7,7 @@ import requests
 from dash import ALL, Input, Output, State, callback, no_update
 from dash.exceptions import PreventUpdate
 
-from utils.data_utils import tiled_dataset
+from utils.data_utils import tiled_masks
 
 MODE = os.getenv("MODE", "")
 
@@ -84,7 +84,7 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
             )
         else:
 
-            tiled_dataset.save_annotations_data(
+            tiled_masks.save_annotations_data(
                 global_store, all_annotations, project_name
             )
             job_submitted = requests.post(

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -74,6 +74,9 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
     """
     if n_clicks:
         if MODE == "dev":
+            tiled_masks.save_annotations_data(
+                global_store, all_annotations, project_name
+            )
             job_uid = str(uuid.uuid4())
             return (
                 dmc.Text(
@@ -83,7 +86,6 @@ def run_job(n_clicks, global_store, all_annotations, project_name):
                 job_uid,
             )
         else:
-
             tiled_masks.save_annotations_data(
                 global_store, all_annotations, project_name
             )

--- a/components/annotation_class.py
+++ b/components/annotation_class.py
@@ -33,7 +33,7 @@ def annotation_class_item(class_color, class_label, existing_ids, data=None):
         annotations = data["annotations"]
         is_visible = data["is_visible"]
     else:
-        class_id = 1 if not existing_ids else max(existing_ids) + 1
+        class_id = 0 if not existing_ids else max(existing_ids) + 1
         annotations = {}
         is_visible = True
     class_color_transparent = class_color + "50"

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -6,7 +6,7 @@ from dash_iconify import DashIconify
 
 from components.annotation_class import annotation_class_item
 from constants import ANNOT_ICONS, KEYBINDS
-from utils.data_utils import tiled_dataset
+from utils.data_utils import tiled_datasets
 
 
 def _tooltip(text, children):
@@ -62,7 +62,7 @@ def layout():
     Returns the layout for the control panel in the app UI
     """
     DATA_OPTIONS = [
-        item for item in tiled_dataset.get_data_project_names() if "seg" not in item
+        item for item in tiled_datasets.get_data_project_names() if "seg" not in item
     ]
     return drawer_section(
         dmc.Stack(

--- a/examples/plot_mask.py
+++ b/examples/plot_mask.py
@@ -19,6 +19,7 @@ def plot_mask(mask_uri, api_key, slice_idx, output_path):
     # Retrieve mask and metadata
     mask_client = from_uri(mask_uri, api_key=api_key)
     mask = mask_client["mask"][slice_idx]
+
     meta_data = mask_client.metadata
     mask_idx = meta_data["mask_idx"]
 
@@ -34,10 +35,14 @@ def plot_mask(mask_uri, api_key, slice_idx, output_path):
     labels = [
         annotation_class["label"] for _, annotation_class in class_meta_data.items()
     ]
+    # Add color for unlabeled pixels
+    colors = ["#D3D3D3"] + colors
+    labels = ["Unlabeled"] + labels
+
     plt.imshow(
         mask,
         cmap=ListedColormap(colors),
-        vmin=-0.5,
+        vmin=-1.5,
         vmax=max_class_id + 0.5,
     )
     plt.title(meta_data["project_name"] + ", slice: " + mask_idx[slice_idx])

--- a/examples/plot_mask.py
+++ b/examples/plot_mask.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+from dotenv import load_dotenv
+from matplotlib.colors import ListedColormap
+from tiled.client import from_uri
+
+
+def plot_mask(mask_uri, api_key, slice_idx, output_path):
+    """
+    Saves a plot of a given mask using metadata information such as class colors and labels.
+    It is assumed that the given uri is the uri of a mask container, with associated meta data
+    and a mask array under the key "mask".
+    The given slice index references mask slices, not the original data.
+    However, the printed slice index in the figure will be the index of the original data.
+    """
+    # Retrieve mask and metadata
+    mask_client = from_uri(mask_uri, api_key=api_key)
+    mask = mask_client["mask"][slice_idx]
+    meta_data = mask_client.metadata
+    mask_idx = meta_data["mask_idx"]
+
+    if slice_idx > len(mask_idx):
+        raise ValueError("Slice index out of range")
+
+    class_meta_data = meta_data["classes"]
+    max_class_id = len(class_meta_data.keys()) - 1
+
+    colors = [
+        annotation_class["color"] for _, annotation_class in class_meta_data.items()
+    ]
+    labels = [
+        annotation_class["label"] for _, annotation_class in class_meta_data.items()
+    ]
+    plt.imshow(
+        mask,
+        cmap=ListedColormap(colors),
+        vmin=-0.5,
+        vmax=max_class_id + 0.5,
+    )
+    plt.title(meta_data["project_name"] + ", slice: " + mask_idx[slice_idx])
+
+    # create a patch for every color
+    patches = [
+        mpatches.Patch(color=colors[i], label=labels[i]) for i in range(len(labels))
+    ]
+    # Plot legend below the image
+    plt.legend(
+        handles=patches, loc="upper center", bbox_to_anchor=(0.5, -0.075), ncol=3
+    )
+    plt.savefig(output_path, bbox_inches="tight")
+
+
+if __name__ == "__main__":
+    """
+    Example usage: python3 plot_mask.py http://localhost:8000/api/v1/metadata/mlex_store/mlex_store/username/dataset/uuid
+    """
+
+    load_dotenv()
+    api_key = os.getenv("MASK_TILED_API_KEY", None)
+
+    if len(sys.argv) < 2:
+        print("Usage: python3 plot_mask.py <mask_uri> [slice_idx] [output_path]")
+        sys.exit(1)
+
+    mask_uri = sys.argv[1]
+    slice_idx = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+    output_path = sys.argv[3] if len(sys.argv) > 3 else "mask.png"
+
+    plot_mask(mask_uri, api_key, slice_idx, output_path)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+tiled[client]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ scipy
 dash-extensions==1.0.1
 dash-bootstrap-components==1.5.0
 dash_auth==2.0.0
+canonicaljson

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -1,8 +1,8 @@
 import hashlib
 import io
-import json
 import zipfile
 
+import canonicaljson
 import numpy as np
 import scipy.sparse as sp
 from matplotlib.path import Path
@@ -62,8 +62,8 @@ class Annotations:
 
     def get_annotations_hash(self):
         hash_object = hashlib.md5()
-        hash_object.update(json.dumps(self.annotations, sort_keys=True).encode())
-        hash_object.update(json.dumps(self.annotation_classes, sort_keys=True).encode())
+        hash_object.update(canonicaljson.encode_canonical_json(self.annotations))
+        hash_object.update(canonicaljson.encode_canonical_json(self.annotation_classes))
         return hash_object.hexdigest()
 
     def get_annotation_mask_as_bytes(self):

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -15,7 +15,9 @@ class Annotations:
             for annotation_class in annotation_store:
                 slices.extend(list(annotation_class["annotations"].keys()))
             slices = set(slices)
-            annotations = {key: [] for key in slices}
+            # Slices need to be sorted to ensure that the exported mask slices
+            # have the same order as the original data set
+            annotations = {key: [] for key in sorted(slices, key=int)}
 
             all_class_labels = [
                 annotation_class["class_id"] for annotation_class in annotation_store

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -1,4 +1,6 @@
+import hashlib
 import io
+import json
 import zipfile
 
 import numpy as np
@@ -46,6 +48,7 @@ class Annotations:
 
         self.annotation_classes = annotation_classes
         self.annotations = annotations
+        self.annotations_hash = self.get_annotations_hash()
         self.image_shape = global_store["image_shapes"][0]
 
     def get_annotations(self):
@@ -56,6 +59,12 @@ class Annotations:
 
     def get_annotation_classes(self):
         return self.annotation_classes
+
+    def get_annotations_hash(self):
+        hash_object = hashlib.md5()
+        hash_object.update(json.dumps(self.annotations, sort_keys=True).encode())
+        hash_object.update(json.dumps(self.annotation_classes, sort_keys=True).encode())
+        return hash_object.hexdigest()
 
     def get_annotation_mask_as_bytes(self):
         buffer = io.BytesIO()

--- a/utils/annotations.py
+++ b/utils/annotations.py
@@ -237,7 +237,7 @@ class ShapeConversion:
         # Reshape the result back into the 2D shape
         mask = is_inside.reshape(image_height, image_width).astype(np.int8)
 
-        # Set the class value for the pixels inside the polygon
-        mask[mask == 1] = mask_class
+        # Set the class value for the pixels inside the polygon, -1 for the rest
         mask[mask == 0] = -1
+        mask[mask == 1] = mask_class
         return mask

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -22,14 +22,14 @@ class TiledDataLoader:
     ):
         self.data_tiled_uri = data_tiled_uri
         self.data_tiled_api_key = data_tiled_api_key
-        self.data = from_uri(
+        self.data_client = from_uri(
             self.data_tiled_uri,
             api_key=self.data_tiled_api_key,
             timeout=httpx.Timeout(30.0),
         )
 
-    def refresh_data(self):
-        self.data = from_uri(
+    def refresh_data_client(self):
+        self.data_client = from_uri(
             self.data_tiled_uri,
             api_key=self.data_tiled_api_key,
             timeout=httpx.Timeout(30.0),
@@ -42,8 +42,8 @@ class TiledDataLoader:
         """
         project_names = [
             project
-            for project in list(self.data)
-            if isinstance(self.data[project], (Container, ArrayClient))
+            for project in list(self.data_client)
+            if isinstance(self.data_client[project], (Container, ArrayClient))
         ]
         return project_names
 
@@ -53,7 +53,7 @@ class TiledDataLoader:
         but can also be additionally encapsulated in a folder, multiple container or in a .nxs file.
         We make use of specs to figure out the path to the 3d data.
         """
-        project_client = self.data[project_name]
+        project_client = self.data_client[project_name]
         # If the project directly points to an array, directly return it
         if isinstance(project_client, ArrayClient):
             return project_client

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -89,6 +89,20 @@ class TiledDataLoader:
             return project_container.shape
         return None
 
+    def get_data_uri_by_name(self, project_name):
+        """
+        Retrieve uri of the data
+        """
+        project_container = self.get_data_sequence_by_name(project_name)
+        if project_container:
+            return project_container.uri
+        return None
+
+
+tiled_datasets = TiledDataLoader(
+    data_tiled_uri=DATA_TILED_URI, data_tiled_api_key=DATA_TILED_API_KEY
+)
+
 
 class TiledMaskHandler:
     """
@@ -169,6 +183,7 @@ class TiledMaskHandler:
             "annotations": annnotations_per_slice,
             "image_shape": global_store["image_shapes"][0],
             "project_name": project_name,
+            "data_uri": tiled_datasets.get_data_uri_by_name(project_name),
             "mask_idx": list(annnotations_per_slice.keys()),
         }
         print("Metadata: ", metadata)
@@ -191,13 +206,9 @@ class TiledMaskHandler:
         # (uuid will be created by Tiled, since no key is given)
         last_container = last_container.create_container(metadata=metadata)
         mask = last_container.write_array(key="mask", array=mask)
-        # print("Created a mask array with the following uri: ", mask.uri)
+
         return mask.uri
 
-
-tiled_datasets = TiledDataLoader(
-    data_tiled_uri=DATA_TILED_URI, data_tiled_api_key=DATA_TILED_API_KEY
-)
 
 tiled_masks = TiledMaskHandler(
     mask_tiled_uri=MASK_TILED_URI, mask_tiled_api_key=MASK_TILED_API_KEY

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -1,6 +1,7 @@
 import random
 
 import dash_mantine_components as dmc
+import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
 from dash_iconify import DashIconify
@@ -168,6 +169,37 @@ def resize_canvas(h, w, H, W, figure):
 
     image_center_coor = {"y1": y1, "y0": y0, "x0": x0, "x1": x1}
     return figure, image_center_coor
+
+
+def generate_segmentation_colormap(all_annotations_data):
+    """
+    Generates a discrete colormap for the segmentation overlay
+    based on the color information per class.
+
+    The discrete colormap maps values from 0 to 1 to colors,
+    but is meant to be applied to images with class ids as values,
+    with these varying from 0 to the number of classes - 1.
+    To account for numerical inaccuracies, it is best to center the plot range
+    around the class ids, by setting cmin=-0.5 and cmax=max_class_id+0.5.
+    """
+    max_class_id = max(
+        [annotation_class["class_id"] for annotation_class in all_annotations_data]
+    )
+    # heatmap requires a normalized range from 0 to 1
+    # We need to specify color for at least the range limits (0 and 1)
+    # as well for every additional class
+    # due to using zero-based class ids, we need to add 2 to the max class id
+    normalized_range = np.linspace(0, 1, max_class_id + 2)
+    color_list = [
+        annotation_class["color"] for annotation_class in all_annotations_data
+    ]
+    colorscale = [
+        [normalized_range[i + j], color_list[i % len(color_list)]]
+        for i in range(0, normalized_range.size - 1)
+        for j in range(2)
+    ]
+
+    return colorscale, max_class_id
 
 
 def generate_notification(title, color, icon, message=""):

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -193,12 +193,14 @@ def generate_segmentation_colormap(all_annotations_data):
     color_list = [
         annotation_class["color"] for annotation_class in all_annotations_data
     ]
+    # We need to repeat each color twice, to create discrete color segments
+    # This loop contains the range limits 0 and 1 once,
+    # but every other value in between twice
     colorscale = [
         [normalized_range[i + j], color_list[i % len(color_list)]]
         for i in range(0, normalized_range.size - 1)
         for j in range(2)
     ]
-
     return colorscale, max_class_id
 
 


### PR DESCRIPTION
This PR makes the following changes:

- Introduces a new class `TiledMaskHandler` for handing mask loading and exporting calls. Currently this includes some legacy file-based code to be removed in the future.
- With that new class, seperates data access into input data, masks, and segmentation results (all of which may live on different Tiled servers)
- Pixelated masks are written to Tiled under `MASK_TILED_URI` + `/USER_NAME/project_name/annotation_hash`. This uri holds the meta data and an additional `mask` child contains the actual pixelated mask. This was original done to support writing annotations meta data for loading, without having to write pixelated masks. The writing happens upon job submission for model training.
- To avoid writing the same mask again (e.g. if no changes have been made to the mask and the user only wants to run a different model), the key under which the mask is saved is a hash of the annotation meta-data (annotation classes with their names and colors, and annotation shapes)
- Resolves #169 by generating a color map from the current set of classes and colors. Note, if the number of classes changed between result writing and visualization, this can lead to inconsistencies. We may choose to instead use the metadata from writing masks in the future. 
- Adds a script `examples/plot_mask.py` to save a colored mask slice based on meta-data. This function could be used to generate a sample image for SciCat.

An example for mask meta data with two annotated slices containing some rectangles and a freeform is given below.

```json
{
   "classes":{
      "0":{
         "color":"#004280",
         "label":"Background"
      },
      "1":{
         "color":"#ffae00",
         "label":"Clay"
      },
      "2":{
         "color":"#ff1900",
         "label":"Clay Anomaly"
      }
   },
   "data_uri":"https://tiled-seg.als.lbl.gov/api/v1/metadata/reconstruction/rec20190524_085542_clay_testZMQ_8bit/20190524_085542_clay_testZMQ_",
   "mask_idx":[
      "64",
      "222"
   ],
   "annotations":{
      "64":[
         {
            "type":"Rectangle",
            "class_id":"0",
            "svg_data":{
               "..."
            }
         },
         {
            "type":"Ellipse",
            "class_id":"1",
            "svg_data":{
               "..."
            }
         }
      ],
      "222":[
         {
            "type":"Closed Freeform",
            "class_id":"0",
            "svg_data":{
               "path":"..."
            }
         },
         {
            "type":"Rectangle",
            "class_id":"0",
            "svg_data":{
               "..."
            }
         },
         {
            "type":"Rectangle",
            "class_id":"1",
            "svg_data":{
               "..."
            }
         },
         {
            "type":"Rectangle",
            "class_id":"1",
            "svg_data":{
               "..."
            }
         },
         {
            "type":"Closed Freeform",
            "class_id":"2",
            "svg_data":{
               "path":"..."
            }
         }
      ]
   },
   "image_shape":[
      1760,
      1760
   ],
   "project_name":"rec20190524_085542_clay_testZMQ_8bit",
   "unlabeled_class_id":-1
}
```

with the second exported colored slice as

![mask](https://github.com/mlexchange/mlex_highres_segmentation/assets/391662/d0279922-b589-4da8-be30-7e52c63a485a)

This partially resolves #160, but annotation export still relies on files.