### PR TITLE
Add string parameter validation and `qlty` parameters

### DIFF
--- a/assets/models.json
+++ b/assets/models.json
@@ -48,7 +48,9 @@
                     "name": "dilation_array",
                     "title": "Dilation Array",
                     "param_key": "dilation_array",
-                    "value": "[1, 2, 4]",
+                    "placeholder": "e.g. [1, 2, 4]",
+                    "error": "Provide a list of ints for dilation",
+                    "debounce": 1000,
                     "comp_group": "train_model"
                 },
                 {
@@ -228,7 +230,9 @@
                     "name": "weights",
                     "title": "Class Weights",
                     "param_key": "weights",
-                    "value": "[1.0, 1.0, 1.0]",
+                    "placeholder": "e.g [0.1, 0.4, 0.5]",
+                    "error": "Provide a list with a float for each class",
+                    "debounce": 1000,
                     "comp_group": "train_model"
                 },
                 {
@@ -616,7 +620,9 @@
                     "name": "weights",
                     "title": "Class Weights",
                     "param_key": "weights",
-                    "value": "[1.0, 1.0, 1.0]",
+                    "placeholder": "e.g [0.1, 0.4, 0.5]",
+                    "error": "Provide a list with a float for each class",
+                    "debounce": 1000,
                     "comp_group": "train_model"
                 },
                 {
@@ -1008,7 +1014,9 @@
                     "name": "weights",
                     "title": "Class Weights",
                     "param_key": "weights",
-                    "value": "[1.0, 1.0, 1.0]",
+                    "placeholder": "e.g [0.1, 0.4, 0.5]",
+                    "error": "Provide a list with a float for each class",
+                    "debounce": 1000,
                     "comp_group": "train_model"
                 },
                 {

--- a/assets/models.json
+++ b/assets/models.json
@@ -274,6 +274,39 @@
                     "comp_group": "train_model"
                 },
                 {
+                    "type": "int",
+                    "name": "qlty_window",
+                    "title": "Qlty Window",
+                    "param_key": "qlty_window",
+                    "value": 64,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_step",
+                    "title": "Qlty Step",
+                    "param_key": "qlty_step",
+                    "value": 32,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_border",
+                    "title": "Qlty Border",
+                    "param_key": "qlty_border",
+                    "value": 8,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
                     "type": "slider",
                     "name": "val_pct",
                     "title": "Validation %",
@@ -661,6 +694,39 @@
                             "value": "Softmax"
                         }
                     ],
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_window",
+                    "title": "Qlty Window",
+                    "param_key": "qlty_window",
+                    "value": 64,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_step",
+                    "title": "Qlty Step",
+                    "param_key": "qlty_step",
+                    "value": 32,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_border",
+                    "title": "Qlty Border",
+                    "param_key": "qlty_border",
+                    "value": 8,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
                     "comp_group": "train_model"
                 },
                 {
@@ -1055,6 +1121,39 @@
                             "value": "Softmax"
                         }
                     ],
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_window",
+                    "title": "Qlty Window",
+                    "param_key": "qlty_window",
+                    "value": 64,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_step",
+                    "title": "Qlty Step",
+                    "param_key": "qlty_step",
+                    "value": 32,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
+                    "comp_group": "train_model"
+                },
+                {
+                    "type": "int",
+                    "name": "qlty_border",
+                    "title": "Qlty Border",
+                    "param_key": "qlty_border",
+                    "value": 8,
+                    "min": 0,
+                    "max": 4096,
+                    "step": 1,
                     "comp_group": "train_model"
                 },
                 {

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -66,6 +66,7 @@ class TiledDataLoader:
         elif isinstance(project_client, Container):
             # Check if the specs give us information about which sub-container to access
             specs = project_client.specs
+            # TODO: Read yaml file with spec to path mapping
             if any(spec.name == "NXtomoproc" for spec in specs):
                 # Example for how to access data if the project container corresponds to a
                 # nexus-file following the NXtomoproc definition
@@ -171,12 +172,13 @@ class TiledMaskHandler:
         if "image_shapes" in global_store:
             image_shape = global_store["image_shapes"][0]
         else:
-            print("Global store was not filled.")
             data_shape = (
                 tiled_datasets.get_data_shape_by_name(project_name)
                 if project_name
                 else None
             )
+            if data_shape is None:
+                return "Image shape could not be determined."
             image_shape = (data_shape[1], data_shape[2])
 
         annotations = Annotations(all_annotations, image_shape)
@@ -192,7 +194,7 @@ class TiledMaskHandler:
         metadata = {
             "project_name": project_name,
             "data_uri": tiled_datasets.get_data_uri_by_name(project_name),
-            "image_shape": global_store["image_shapes"][0],
+            "image_shape": image_shape,
             "mask_idx": list(annnotations_per_slice.keys()),
             "classes": annotation_classes,
             "annotations": annnotations_per_slice,


### PR DESCRIPTION
This PR validates the string parameters `weights` and `dilation_array` to have the correct format, such that they can be parsed as expected in mlexchange/mlex_dlsia_segmentation_prototype#12, and checks if class labels are non-empty.

Additionally, this adds parameters `qlty_step`, `qlty_window`, `qlty_border` for use of [`qlty`](https://github.com/phzwart/qlty) and extends a bug fix that wasn't fully followed through in 6193c53.