### PR TITLE
Update prefect query functions

### DIFF
--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -59,7 +59,9 @@ def get_flow_run_name(flow_run_id):
     return asyncio.run(_get_name(flow_run_id))
 
 
-async def _flow_run_query(tags=None, flow_run_name=None, parent_flow_run_id=None):
+async def _flow_run_query(
+    tags=None, flow_run_name=None, parent_flow_run_id=None, sort="START_TIME_DESC"
+):
     flow_run_filter_parent_flow_run_id = (
         FlowRunFilterParentFlowRunId(any_=[parent_flow_run_id])
         if parent_flow_run_id
@@ -72,7 +74,7 @@ async def _flow_run_query(tags=None, flow_run_name=None, parent_flow_run_id=None
                 parent_flow_run_id=flow_run_filter_parent_flow_run_id,
                 tags=FlowRunFilterTags(all_=tags),
             ),
-            sort="START_TIME_DESC",
+            sort=sort,
         )
         return flow_runs
 
@@ -91,11 +93,11 @@ def get_flow_runs_statuses(flow_run_name=None, tags=None):
     return flow_runs_by_name
 
 
-def get_children_flows_run_ids(parent_flow_run_id):
+def get_children_flows_run_ids(parent_flow_run_id, sort="START_TIME_ASC"):
     children_flow_runs = asyncio.run(
-        _flow_run_query(parent_flow_run_id=parent_flow_run_id)
+        _flow_run_query(parent_flow_run_id=parent_flow_run_id, sort=sort)
     )
     children_flow_run_ids = [
-        children_flow_run.id for children_flow_run in children_flow_runs
+        str(children_flow_run.id) for children_flow_run in children_flow_runs
     ]
     return children_flow_run_ids

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -79,7 +79,7 @@ async def _flow_run_query(
         return flow_runs
 
 
-def get_flow_runs_statuses(flow_run_name=None, tags=None):
+def get_flow_runs_by_name(flow_run_name=None, tags=None):
     flow_runs_by_name = []
     flow_runs = asyncio.run(_flow_run_query(tags, flow_run_name=flow_run_name))
     for flow_run in flow_runs:
@@ -93,7 +93,7 @@ def get_flow_runs_statuses(flow_run_name=None, tags=None):
     return flow_runs_by_name
 
 
-def get_children_flows_run_ids(parent_flow_run_id, sort="START_TIME_ASC"):
+def get_children_flow_run_ids(parent_flow_run_id, sort="START_TIME_ASC"):
     children_flow_runs = asyncio.run(
         _flow_run_query(parent_flow_run_id=parent_flow_run_id, sort=sort)
     )

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -5,6 +5,7 @@ from prefect import get_client
 from prefect.client.schemas.filters import (
     FlowRunFilter,
     FlowRunFilterName,
+    FlowRunFilterParentFlowRunId,
     FlowRunFilterTags,
 )
 
@@ -58,26 +59,37 @@ def get_flow_run_name(flow_run_id):
     return asyncio.run(_get_name(flow_run_id))
 
 
-async def _flow_run_query(tags, flow_run_name=None):
-    flow_runs_by_name = []
+async def _flow_run_query(tags=None, flow_run_name=None, parent_flow_run_id=None):
+    flow_run_filter_parent_flow_run_id = FlowRunFilterParentFlowRunId(
+        any_=[parent_flow_run_id]
+        ) if parent_flow_run_id else None
     async with get_client() as client:
         flow_runs = await client.read_flow_runs(
             flow_run_filter=FlowRunFilter(
                 name=FlowRunFilterName(like_=flow_run_name),
+                parent_flow_run_id=flow_run_filter_parent_flow_run_id,
                 tags=FlowRunFilterTags(all_=tags),
             ),
             sort="START_TIME_DESC",
         )
-        for flow_run in flow_runs:
-            if flow_run.state_name == "Failed":
-                flow_name = f"❌ {flow_run.name}"
-            elif flow_run.state_name == "Completed":
-                flow_name = f"✅ {flow_run.name}"
-            else:
-                flow_name = f"🕑 {flow_run.name}"
-            flow_runs_by_name.append({"label": flow_name, "value": str(flow_run.id)})
-        return flow_runs_by_name
+        return flow_runs
 
 
-def query_flow_run(tags, flow_run_name=None):
-    return asyncio.run(_flow_run_query(tags, flow_run_name))
+def get_flow_runs_statuses(flow_run_name=None, tags=None):
+    flow_runs_by_name = []
+    flow_runs = asyncio.run(_flow_run_query(tags, flow_run_name=flow_run_name))
+    for flow_run in flow_runs:
+        if flow_run.state_name == "Failed":
+            flow_name = f"❌ {flow_run.name}"
+        elif flow_run.state_name == "Completed":
+            flow_name = f"✅ {flow_run.name}"
+        else:
+            flow_name = f"🕑 {flow_run.name}"
+        flow_runs_by_name.append({"label": flow_name, "value": str(flow_run.id)})
+    return flow_runs_by_name
+
+
+def get_children_flows_run_ids(parent_flow_run_id):
+    children_flow_runs = asyncio.run(_flow_run_query(parent_flow_run_id=parent_flow_run_id))
+    children_flow_run_ids = [children_flow_run.id for children_flow_run in children_flow_runs]
+    return children_flow_run_ids

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -83,10 +83,12 @@ def get_flow_runs_by_name(flow_run_name=None, tags=None):
     flow_runs_by_name = []
     flow_runs = asyncio.run(_flow_run_query(tags, flow_run_name=flow_run_name))
     for flow_run in flow_runs:
-        if flow_run.state_name == "Failed":
+        if flow_run.state_name in {"Failed", "Crashed"}:
             flow_name = f"❌ {flow_run.name}"
         elif flow_run.state_name == "Completed":
             flow_name = f"✅ {flow_run.name}"
+        elif flow_run.state_name == "Cancelled":
+            flow_name = f"🚫 {flow_run.name}"
         else:
             flow_name = f"🕑 {flow_run.name}"
         flow_runs_by_name.append({"label": flow_name, "value": str(flow_run.id)})

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -60,9 +60,11 @@ def get_flow_run_name(flow_run_id):
 
 
 async def _flow_run_query(tags=None, flow_run_name=None, parent_flow_run_id=None):
-    flow_run_filter_parent_flow_run_id = FlowRunFilterParentFlowRunId(
-        any_=[parent_flow_run_id]
-        ) if parent_flow_run_id else None
+    flow_run_filter_parent_flow_run_id = (
+        FlowRunFilterParentFlowRunId(any_=[parent_flow_run_id])
+        if parent_flow_run_id
+        else None
+    )
     async with get_client() as client:
         flow_runs = await client.read_flow_runs(
             flow_run_filter=FlowRunFilter(
@@ -90,6 +92,10 @@ def get_flow_runs_statuses(flow_run_name=None, tags=None):
 
 
 def get_children_flows_run_ids(parent_flow_run_id):
-    children_flow_runs = asyncio.run(_flow_run_query(parent_flow_run_id=parent_flow_run_id))
-    children_flow_run_ids = [children_flow_run.id for children_flow_run in children_flow_runs]
+    children_flow_runs = asyncio.run(
+        _flow_run_query(parent_flow_run_id=parent_flow_run_id)
+    )
+    children_flow_run_ids = [
+        children_flow_run.id for children_flow_run in children_flow_runs
+    ]
     return children_flow_run_ids


### PR DESCRIPTION
This PR updated the query-related functions according to mlexchange/mlex_prefect_worker#16 In particular, it adds:
- Retrieving children flow run ids according to a given parent flow run id. These are sorted according to `START_TIME_ASC` by default, with the child flow that started first being at the beginning of the list
- Minor change to query function, such that it can be used for both (1) retrieving flows by names, and (2) querying children flows