### PR TITLE
Improve startup robustness and monitoring for connected services

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from dash import Dash
 
 from callbacks.control_bar import *  # noqa: F403, F401
 from callbacks.image_viewer import *  # noqa: F403, F401
+from callbacks.infrastructure_check import *  # noqa: F403, F401
 from callbacks.segmentation import *  # noqa: F403, F401
 from components.control_bar import layout as control_bar_layout
 from components.image_viewer import layout as image_viewer_layout

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -129,6 +129,7 @@ def render_image(
                 seg_result = (
                     seg_result_inference if seg_result_inference else seg_result_train
                 )
+
                 if "mask_idx" in seg_result and seg_result["mask_idx"] is not None:
                     annotation_indices = seg_result["mask_idx"]
                     if image_idx in annotation_indices:
@@ -139,6 +140,8 @@ def render_image(
                         )
                     else:
                         result = None
+                # if mask_idx is not given in the results,
+                # then the result stems from inference on the full data set
                 else:
                     result = tiled_results.get_data_by_trimmed_uri(
                         seg_result["seg_result_trimmed_uri"], slice=image_idx

--- a/callbacks/infrastructure_check.py
+++ b/callbacks/infrastructure_check.py
@@ -30,7 +30,7 @@ def check_infra_state(n_intervals):
     infra_state["tiled_data_ready"] = tiled_data_ready
     if not tiled_data_ready:
         any_infra_down = True
-    tiled_masks_ready = tiled_masks.check_mask_handler()
+    tiled_masks_ready = tiled_masks.check_mask_handler_ready()
     infra_state["tiled_masks_ready"] = tiled_masks_ready
     if not tiled_masks_ready:
         any_infra_down = True

--- a/callbacks/infrastructure_check.py
+++ b/callbacks/infrastructure_check.py
@@ -1,0 +1,98 @@
+import os
+from datetime import datetime
+
+import pytz
+from dash import Input, Output, callback, no_update
+
+from components.control_bar import create_infra_state_details
+from utils.data_utils import tiled_datasets, tiled_masks, tiled_results
+from utils.plot_utils import generate_notification
+from utils.prefect import check_prefect_ready, check_prefect_worker_ready
+
+TIMEZONE = os.getenv("TIMEZONE", "US/Pacific")
+FLOW_NAME = os.getenv("FLOW_NAME", "")
+
+
+@callback(
+    Output("infra-state", "data"),
+    Input("infra-check", "n_intervals"),
+)
+def check_infra_state(n_intervals):
+    infra_state = {}
+
+    current_time = datetime.now(pytz.timezone(TIMEZONE)).strftime("%Y/%m/%d %H:%M:%S")
+    infra_state["last_checked"] = current_time
+
+    any_infra_down = False
+
+    # Tiled: Check if data, masks, and results are reachable (from_uri did not raise an exception)
+    tiled_data_ready = tiled_datasets.check_loader()
+    infra_state["tiled_data_ready"] = tiled_data_ready
+    if not tiled_data_ready:
+        any_infra_down = True
+    tiled_masks_ready = tiled_masks.check_mask_handler()
+    infra_state["tiled_masks_ready"] = tiled_masks_ready
+    if not tiled_masks_ready:
+        any_infra_down = True
+    tiled_results_ready = tiled_results.check_loader()
+    infra_state["tiled_results_ready"] = tiled_results_ready
+    if not tiled_results_ready:
+        any_infra_down = True
+
+    # Prefect: Check prefect API is reachable, and the worker is ready (flow is deployed and ready)
+    try:
+        check_prefect_ready()
+        infra_state["prefect_ready"] = True
+    except Exception:
+        any_infra_down = True
+        infra_state["prefect_ready"] = False
+    try:
+        check_prefect_worker_ready(FLOW_NAME)
+        infra_state["prefect_worker_ready"] = True
+    except Exception:
+        any_infra_down = True
+        infra_state["prefect_worker_ready"] = False
+    if any_infra_down:
+        infra_state["any_infra_down"] = True
+    return infra_state
+
+
+@callback(
+    Output("infra-state-icon", "icon"),
+    Output("infra-state-summary", "color"),
+    Output("infra-state-details", "children"),
+    Output("notifications-container", "children", allow_duplicate=True),
+    Input("infra-state", "data"),
+    prevent_initial_call=True,
+)
+def update_infra_state(infra_state):
+
+    if infra_state is None:
+        return no_update, no_update, no_update, no_update
+
+    any_infra_down = infra_state["any_infra_down"]
+    last_checked = f"{infra_state['last_checked']}"
+
+    infra_details = create_infra_state_details(
+        tiled_data_ready=infra_state["tiled_data_ready"],
+        tiled_masks_ready=infra_state["tiled_masks_ready"],
+        tiled_results_ready=infra_state["tiled_results_ready"],
+        prefect_ready=infra_state["prefect_ready"],
+        prefect_worker_ready=infra_state["prefect_worker_ready"],
+        timestamp=last_checked,
+    )
+
+    if any_infra_down:
+        notification = generate_notification(
+            "Infrastructure State",
+            "red",
+            "ph:network-x",
+            "One or more infrastructure components are not reachable!",
+        )
+        infra_state_icon = "ph:network-x"
+        infra_state_color = "red"
+    else:
+        notification = no_update
+        infra_state_icon = "ph:network-fill"
+        infra_state_color = "gray"
+    return infra_state_icon, infra_state_color, infra_details, notification

--- a/callbacks/infrastructure_check.py
+++ b/callbacks/infrastructure_check.py
@@ -26,7 +26,7 @@ def check_infra_state(n_intervals):
     any_infra_down = False
 
     # Tiled: Check if data, masks, and results are reachable (from_uri did not raise an exception)
-    tiled_data_ready = tiled_datasets.check_loader()
+    tiled_data_ready = tiled_datasets.check_dataloader_ready()
     infra_state["tiled_data_ready"] = tiled_data_ready
     if not tiled_data_ready:
         any_infra_down = True
@@ -34,7 +34,8 @@ def check_infra_state(n_intervals):
     infra_state["tiled_masks_ready"] = tiled_masks_ready
     if not tiled_masks_ready:
         any_infra_down = True
-    tiled_results_ready = tiled_results.check_loader()
+    # The segmentation application will make sure that all containers that are needed exist
+    tiled_results_ready = tiled_results.check_dataloader_ready(base_uri_only=True)
     infra_state["tiled_results_ready"] = tiled_results_ready
     if not tiled_results_ready:
         any_infra_down = True

--- a/callbacks/infrastructure_check.py
+++ b/callbacks/infrastructure_check.py
@@ -54,6 +54,8 @@ def check_infra_state(n_intervals):
         infra_state["prefect_worker_ready"] = False
     if any_infra_down:
         infra_state["any_infra_down"] = True
+    else:
+        infra_state["any_infra_down"] = False
     return infra_state
 
 

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -324,8 +324,9 @@ def run_inference(
 @callback(
     Output("train-job-selector", "data"),
     Input("model-check", "n_intervals"),
+    State("infra-state", "data"),
 )
-def check_train_job(n_intervals):
+def check_train_job(n_intervals, infra_state):
     """
     This callback populates the train job selector dropdown with job names and ids from Prefect.
     This callback displays the current status of the job as part of the job name in the dropdown.
@@ -338,7 +339,10 @@ def check_train_job(n_intervals):
             {"label": "✅ DLSIA CBA 03/11/2024 10:02AM", "value": "uid0003"},
         ]
     else:
-        data = get_flow_runs_by_name(tags=PREFECT_TAGS + ["train"])
+        if infra_state is not None and infra_state["prefect_ready"]:
+            data = get_flow_runs_by_name(tags=PREFECT_TAGS + ["train"])
+        else:
+            data = []
     return data
 
 

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -422,6 +422,9 @@ def populate_segmentation_results(
                 job_id = children_flows[0]
             expected_result_uri = f"{job_id}/seg_result"
             try:
+                # First refresh the data client,
+                # the root container may not yet have existed on startup
+                tiled_results.refresh_data_client()
                 result_container = tiled_results.get_data_by_trimmed_uri(
                     expected_result_uri
                 )

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -404,17 +404,21 @@ def populate_segmentation_results(
 ):
     """
     This function populates the segmentation results store based on the uids
-    of the training job orinference job.
+    of the training job or inference job.
     """
-    data_uri = tiled_datasets.get_data_uri_by_name(project_name)
+    # Nothing has been selected is job_id is None
     if job_id is not None:
+        data_uri = tiled_datasets.get_data_uri_by_name(project_name)
+        # Only returns the name if the job finished successfully
         job_name = get_flow_run_name(job_id)
         if job_name is not None:
             children_flows = get_children_flow_run_ids(job_id)
             if job_type == "training":
                 # Get second child to retrieve results
+                # (inference on just annotated slices for the training job)
                 job_id = children_flows[1]
             else:
+                # There will be only one child
                 job_id = children_flows[0]
             expected_result_uri = f"{job_id}/seg_result"
             try:

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -764,12 +764,15 @@ def drawer_section(children):
             create_reset_view_affix(),
             create_info_card_affix(),
             create_viewfinder_affix(),
+            create_infra_state_affix(),
             dmc.NotificationsProvider(html.Div(id="notifications-container")),
             dcc.Download(id="export-annotation-metadata"),
             dcc.Download(id="export-annotation-mask"),
             dcc.Interval(
                 id="model-check", interval=5000
             ),  # TODO: May want to increase frequency
+            dcc.Interval(id="infra-check", interval=60000),
+            dcc.Store(id="infra-state"),
             html.Div(id="dummy-output"),
             EventListener(
                 events=[
@@ -798,7 +801,7 @@ def create_keybind_row(keys, text):
 
 def create_reset_view_affix():
     return dmc.Affix(
-        position={"bottom": 60, "right": 20},
+        position={"bottom": 100, "right": 20},
         zIndex=9999999,
         children=_tooltip(
             text="Center the image",
@@ -835,7 +838,7 @@ def create_viewfinder_affix():
 
 def create_info_card_affix():
     return dmc.Affix(
-        position={"bottom": 20, "right": 20},
+        position={"bottom": 60, "right": 20},
         zIndex=9999999,
         children=dmc.HoverCard(
             shadow="md",
@@ -901,6 +904,110 @@ def create_info_card_affix():
                             p=0,
                         ),
                     ],
+                ),
+            ],
+        ),
+    )
+
+
+def create_infra_state_status(title, icon, id, color):
+    return dmc.Group(
+        position="left",
+        children=[
+            DashIconify(icon=icon, width=20, color=color, id=id),
+            dmc.Text(title, size="sm"),
+        ],
+    )
+
+
+def create_infra_state_details(
+    tiled_data_ready=False,
+    tiled_masks_ready=False,
+    tiled_results_ready=False,
+    prefect_ready=False,
+    prefect_worker_ready=False,
+    timestamp=None,
+):
+    not_ready_icon = "pajamas:warning-solid"
+    not_ready_color = "red"
+    ready_icon = "pajamas:warning-solid"
+    ready_color = "green"
+
+    children = [
+        dmc.Text(
+            "Infrastructure",
+            size="lg",
+            weight=700,
+        ),
+        dmc.Text(
+            "----/--/-- --:--:--" if timestamp is None else timestamp,
+            size="sm",
+            id="infra-state-last-checked",
+        ),
+        dmc.Stack(
+            [
+                dmc.Space(h=2),
+                dmc.Divider(variant="solid", color="gray"),
+                create_infra_state_status(
+                    "Tiled (Input)",
+                    icon=ready_icon if tiled_data_ready else not_ready_icon,
+                    color=ready_color if tiled_data_ready else not_ready_color,
+                    id="tiled-data-ready",
+                ),
+                create_infra_state_status(
+                    "Tiled (Masks)",
+                    icon=ready_icon if tiled_masks_ready else not_ready_icon,
+                    color=ready_color if tiled_masks_ready else not_ready_color,
+                    id="tiled-masks-ready",
+                ),
+                create_infra_state_status(
+                    "Tiled (Results)",
+                    icon=ready_icon if tiled_results_ready else not_ready_icon,
+                    color=ready_color if tiled_results_ready else not_ready_color,
+                    id="tiled-results-ready",
+                ),
+                dmc.Divider(variant="solid", color="gray"),
+                create_infra_state_status(
+                    "Prefect (Server)",
+                    icon=ready_icon if prefect_ready else not_ready_icon,
+                    color=ready_color if prefect_ready else not_ready_color,
+                    id="prefect-ready",
+                ),
+                create_infra_state_status(
+                    "Prefect (Worker)",
+                    icon=ready_icon if prefect_worker_ready else not_ready_icon,
+                    color=ready_color if prefect_worker_ready else not_ready_color,
+                    id="prefect-worker-ready",
+                ),
+            ],
+            p=0,
+        ),
+    ]
+    return children
+
+
+def create_infra_state_affix():
+    return dmc.Affix(
+        position={"bottom": 20, "right": 20},
+        zIndex=9999999,
+        children=dmc.HoverCard(
+            shadow="md",
+            position="top-start",
+            children=[
+                dmc.HoverCardTarget(
+                    dmc.ActionIcon(
+                        DashIconify(icon="ph:network-fill", id="infra-state-icon"),
+                        size="lg",
+                        radius="lg",
+                        variant="filled",
+                        mb=10,
+                        id="infra-state-summary",
+                    ),
+                ),
+                dmc.HoverCardDropdown(
+                    style={"marginRight": "20px"},
+                    id="infra-state-details",
+                    children=create_infra_state_details(),
                 ),
             ],
         ),

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -930,7 +930,7 @@ def create_infra_state_details(
 ):
     not_ready_icon = "pajamas:warning-solid"
     not_ready_color = "red"
-    ready_icon = "pajamas:warning-solid"
+    ready_icon = "pajamas:check-circle-filled"
     ready_color = "green"
 
     children = [

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -10,6 +10,31 @@ from prefect.client.schemas.filters import (
 )
 
 
+async def _check_prefect_ready():
+    async with get_client() as client:
+        healthcheck_result = await client.api_healthcheck()
+        if healthcheck_result is not None:
+            raise Exception("Prefect API is not healthy.")
+
+
+def check_prefect_ready():
+    return asyncio.run(_check_prefect_ready())
+
+
+async def _check_prefect_worker_ready(deployment_name: str):
+    async with get_client() as client:
+        deployment = await client.read_deployment_by_name(deployment_name)
+        assert (
+            deployment
+        ), f"No deployment found in config for deployment_name {deployment_name}"
+        if deployment.status != "Ready":
+            raise Exception("Deployment used for training and inference is not ready.")
+
+
+def check_prefect_worker_ready(deployment_name: str):
+    return asyncio.run(_check_prefect_worker_ready(deployment_name))
+
+
 async def _schedule(
     deployment_name: str,
     flow_run_name: str,

--- a/utils/prefect.py
+++ b/utils/prefect.py
@@ -8,6 +8,7 @@ from prefect.client.schemas.filters import (
     FlowRunFilterParentFlowRunId,
     FlowRunFilterTags,
 )
+from prefect.client.schemas.objects import DeploymentStatus
 
 
 async def _check_prefect_ready():
@@ -27,7 +28,7 @@ async def _check_prefect_worker_ready(deployment_name: str):
         assert (
             deployment
         ), f"No deployment found in config for deployment_name {deployment_name}"
-        if deployment.status != "Ready":
+        if deployment.status != DeploymentStatus.READY:
             raise Exception("Deployment used for training and inference is not ready.")
 
 


### PR DESCRIPTION
This PR adds a new affix to the interface indicating the reachability of infrastructure including access to Tiled for input data, masks, and segmentation results, as well as Prefect server and Prefect worker. Additionally, infrastructure components not being available no longer hinders startup of the application, but instead issues a warning.

Reachability is queried once per minute. Since Prefect is also querying the state of its workers at an interval of a minute, there may be a delay in recognizing if the Prefect worker is up an running. 



Adresses #180.