### PR TITLE
Updated Tiled to `0.2.0`, Dash to `2.18.1` and fix annotation export issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ python save_mlflow_algorithm.py
 For local testing of just the annotation functionality, developers may also choose to set up a local Tiled server with access to minimal datasets (eg. in the case that the remote server is down).
 
 To download some sample data and serve it with a local Tiled serve
-1. Additionally install the Tiled server components with `pip install "tiled[server]==0.1.0a114"`.
+1. Additionally install the Tiled server components with `pip install "tiled[server]==0.2.0"`.
 2. Set the input Tiled URI to localhost, e.g. set `DATA_TILED_URI`, to `http://localhost:8000/` within the `.env` file (or within your environmental variables), and use the result of a key generator (e.g. with `python3 -c "import secrets; print(secrets.token_hex(32))"`) for the key entry `DATA_TILED_API_KEY`
 2. Run the script `python3 utils/download_sample_data.py`. This will create a `data/` directory and download 2 sample projects with 2 images each.
 3. Run `/tiled_serve_dir.sh`.

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -36,6 +36,9 @@ from utils.plot_utils import generate_notification, generate_notification_bg_ico
 EXPORT_FILE_PATH = os.getenv("EXPORT_FILE_PATH", "exported_annotation_data.json")
 USER_NAME = os.getenv("USER_NAME", "user1")
 
+# Ensure parent directory exists
+os.makedirs(os.path.dirname(EXPORT_FILE_PATH), exist_ok=True)
+
 # Create an empty file if it doesn't exist
 if not os.path.exists(EXPORT_FILE_PATH):
     open(EXPORT_FILE_PATH, "w").close()

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -37,7 +37,9 @@ EXPORT_FILE_PATH = os.getenv("EXPORT_FILE_PATH", "exported_annotation_data.json"
 USER_NAME = os.getenv("USER_NAME", "user1")
 
 # Ensure parent directory exists
-os.makedirs(os.path.dirname(EXPORT_FILE_PATH), exist_ok=True)
+export_dir = os.path.dirname(EXPORT_FILE_PATH)
+if export_dir:
+    os.makedirs(export_dir, exist_ok=True)
 
 # Create an empty file if it doesn't exist
 if not os.path.exists(EXPORT_FILE_PATH):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tifffile==2023.4.12
 tzdata==2023.3
 Werkzeug==2.2.3
 zipp==3.15.0
-tiled[client]==0.1.0a114
+tiled[client]==0.2.0
 gunicorn==20.1.0
 requests
 python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-dash==2.9.3
+dash==2.18.1
 dash-core-components==2.0.0
 dash-html-components==2.0.0
 dash-iconify==0.1.2


### PR DESCRIPTION
This PR performs several maintenance updates and fixes:

- **Upgrade Tiled to `0.2.0`**  
No code changes needed as functions for retrieving data and writing arrays have the same signature
- **Upgrade Dash to `2.18.1`**  
  This is the final release of Dash v2. The update restores the ability to delete shapes (see #205), but also reintroduces the issue where annotations disappear on resize. This strongly points to the introduction of `deleteActiveShape` having something to do with annotations disappearing on resizing.

- **Fix annotation writing error due to missing export directory**  
  If `EXPORT_FILE_PATH` points to a directory that doesn't yet exist, the application will fail to write annotations. 