### PR TITLE
Xiaoya add sam3

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,14 @@
-import os
-import tempfile
-
 # Configure logging at the earliest possible point
 import logging
+import os
 import sys
+import tempfile
 
 # Set up basic configuration
 logging.basicConfig(
     level=logging.INFO,  # Use DEBUG to see all logs
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 # Create logger for this module
@@ -21,7 +20,7 @@ logging.getLogger("seg").setLevel(logging.INFO)
 
 # Force propagation for all existing seg loggers
 for name in logging.root.manager.loggerDict:
-    if name.startswith('seg.'):
+    if name.startswith("seg."):
         logging.getLogger(name).propagate = True
 
 import dash_auth

--- a/app.py
+++ b/app.py
@@ -1,6 +1,29 @@
 import os
 import tempfile
 
+# Configure logging at the earliest possible point
+import logging
+import sys
+
+# Set up basic configuration
+logging.basicConfig(
+    level=logging.INFO,  # Use DEBUG to see all logs
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+
+# Create logger for this module
+logger = logging.getLogger("seg")
+logger.info("Logging configured. Frontend module initializing.")
+
+# Explicitly set level for seg namespace
+logging.getLogger("seg").setLevel(logging.INFO)
+
+# Force propagation for all existing seg loggers
+for name in logging.root.manager.loggerDict:
+    if name.startswith('seg.'):
+        logging.getLogger(name).propagate = True
+
 import dash_auth
 import dash_mantine_components as dmc
 from dash import Dash

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -548,16 +548,17 @@ def re_draw_annotations_after_editing_class_color(
     """
     fig = Patch()
     image_idx = str(image_idx - 1)
-    
+
     # ✅ Determine which source to show
     target_source = "original" if mask_source == "annotations" else "sam3"
-    
+
     all_annotations = []
     for a in all_annotation_class_store:
         if a["is_visible"] and "annotations" in a and image_idx in a["annotations"]:
             # ✅ Filter by source
             filtered_shapes = [
-                s for s in a["annotations"][image_idx]
+                s
+                for s in a["annotations"][image_idx]
                 if s.get("source") == target_source
             ]
             all_annotations += filtered_shapes
@@ -644,16 +645,17 @@ def hide_show_annotations_on_fig(
     """This callback hides or shows all annotations for a given class by Patching the figure accordingly"""
     fig = Patch()
     image_idx = str(image_idx - 1)
-    
+
     # ✅ Determine which source to show
     target_source = "original" if mask_source == "annotations" else "sam3"
-    
+
     all_annotations = []
     for a in all_annotation_class_store:
         if a["is_visible"] and "annotations" in a and image_idx in a["annotations"]:
             # ✅ Filter by source
             filtered_shapes = [
-                s for s in a["annotations"][image_idx]
+                s
+                for s in a["annotations"][image_idx]
                 if s.get("source") == target_source
             ]
             all_annotations += filtered_shapes
@@ -1226,8 +1228,11 @@ def refine_bbox_with_sam3(
             if slice_key in annotation_class["annotations"]:
                 # Keep only non-SAM3 shapes, mark rectangles as "original"
                 annotation_class["annotations"][slice_key] = [
-                    {**shape, "source": "original"} if shape.get("type") == "rect" and shape.get("source") is None
-                    else shape
+                    (
+                        {**shape, "source": "original"}
+                        if shape.get("type") == "rect" and shape.get("source") is None
+                        else shape
+                    )
                     for shape in annotation_class["annotations"][slice_key]
                     if shape.get("source") != "sam3"  # Remove old SAM3
                 ]

--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -35,15 +35,14 @@ from constants import ANNOT_ICONS, ANNOT_NOTIFICATION_MSGS, KEY_MODES, KEYBINDS
 from utils.annotations import Annotations
 from utils.data_utils import models, tiled_datasets, tiled_masks
 from utils.plot_utils import generate_notification, generate_notification_bg_icon_col
-from utils.sam3_utils import (
-    overlay_masks, 
-    prepare_masks_for_overlay, 
-    sam3_segmenter,
-    # Add these new helper functions:
+from utils.sam3_utils import (  # Add these new helper functions:
+    convert_sam3_masks_to_numpy,
+    create_overlay_figure,
     extract_rectangles_by_class,
     load_and_prepare_image,
-    create_overlay_figure,
-    convert_sam3_masks_to_numpy,
+    overlay_masks,
+    prepare_masks_for_overlay,
+    sam3_segmenter,
     segment_all_classes_with_sam3,
 )
 
@@ -1196,7 +1195,9 @@ def refine_bbox_with_sam3(
 
     try:
         image_data = tiled_datasets.get_data_sequence_by_trimmed_uri(image_uri)[img_idx]
-        logger.info(f"Image loaded - shape: {image_data.shape}, dtype: {image_data.dtype}")
+        logger.info(
+            f"Image loaded - shape: {image_data.shape}, dtype: {image_data.dtype}"
+        )
         image_pil = load_and_prepare_image(image_data)
     except Exception as e:
         logger.error(f"Error loading image: {str(e)}", exc_info=True)
@@ -1211,11 +1212,7 @@ def refine_bbox_with_sam3(
     # Step 3: Run SAM3 segmentation for all classes
     try:
         all_masks, all_colors, class_results_summary = segment_all_classes_with_sam3(
-            image_pil, 
-            class_boxes, 
-            sam3_segmenter,
-            threshold=0.5,
-            mask_threshold=0.5
+            image_pil, class_boxes, sam3_segmenter, threshold=0.5, mask_threshold=0.5
         )
 
         if all_masks is None:
@@ -1256,7 +1253,9 @@ def refine_bbox_with_sam3(
         }
 
         logger.info(f"SAM3 mask stored for slice {slice_key}")
-        logger.info(f"Mask shape: {slice_mask.shape}, unique values: {np.unique(slice_mask)}")
+        logger.info(
+            f"Mask shape: {slice_mask.shape}, unique values: {np.unique(slice_mask)}"
+        )
 
         # Step 7: Enable SAM3 option in dropdown
         updated_dropdown_options = [

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -156,15 +156,19 @@ def render_image(
         for a_class in all_annotation_class_store:
             if str(image_idx) in a_class["annotations"] and a_class["is_visible"]:
                 slice_shapes = a_class["annotations"][str(image_idx)]
-                
+
                 # Filter based on mask_source selection
                 if mask_source == "sam3":
                     # Show only SAM3 polygons
-                    filtered_shapes = [s for s in slice_shapes if s.get("source") == "sam3"]
+                    filtered_shapes = [
+                        s for s in slice_shapes if s.get("source") == "sam3"
+                    ]
                 else:
                     # Show only original annotations (not SAM3)
-                    filtered_shapes = [s for s in slice_shapes if s.get("source") != "sam3"]
-                
+                    filtered_shapes = [
+                        s for s in slice_shapes if s.get("source") != "sam3"
+                    ]
+
                 # ===== ADDED: Remove 'source' property before adding to figure =====
                 for shape in filtered_shapes:
                     shape_copy = shape.copy()
@@ -216,6 +220,7 @@ def render_image(
         curr_image_metadata,
         "hidden",
     )
+
 
 @callback(
     Output("image-selection-slider", "value", allow_duplicate=True),

--- a/callbacks/image_viewer.py
+++ b/callbacks/image_viewer.py
@@ -416,9 +416,7 @@ clientside_callback(
 
 
 @callback(
-    Output(
-        {"type": "annotation-class-store", "index": ALL}, "data", allow_duplicate=True
-    ),
+    Output({"type": "annotation-class-store", "index": ALL}, "data", allow_duplicate=True),
     Output("annotation-store", "data", allow_duplicate=True),
     Output("image-viewer", "figure", allow_duplicate=True),
     Input("image-viewer", "relayoutData"),
@@ -426,18 +424,20 @@ clientside_callback(
     State("annotation-store", "data"),
     State({"type": "annotation-class-store", "index": ALL}, "data"),
     State("image-viewer", "figure"),
+    State("mask-source-selector", "value"),
     prevent_initial_call=True,
 )
 def locally_store_annotations(
-    relayout_data, img_idx, annotation_store, all_annotation_class_store, fig
+    relayout_data, img_idx, annotation_store, all_annotation_class_store, fig, mask_source
 ):
     """
     Upon finishing a relayout event (drawing, modifying, panning or zooming), this function takes the
-    currently drawn shapes or zoom/pan data, and stores the lastest added shape to the
-    appropriate class-annotation-store, or the image pan/zoom position to the anntations-store.
+    currently drawn shapes or zoom/pan data, and stores the latest added shape to the
+    appropriate class-annotation-store, or the image pan/zoom position to the annotations-store.
     """
     img_idx = str(img_idx - 1)
     shapes = []
+    
     # Case 1: panning/zooming, no need to update all the class annotation stores
     if "xaxis.range[0]" in relayout_data:
         annotation_store["view"]["xaxis_range_0"] = relayout_data["xaxis.range[0]"]
@@ -445,41 +445,65 @@ def locally_store_annotations(
         annotation_store["view"]["yaxis_range_0"] = relayout_data["yaxis.range[0]"]
         annotation_store["view"]["yaxis_range_1"] = relayout_data["yaxis.range[1]"]
         return all_annotation_class_store, annotation_store, dash.no_update
-    # Case 2: A shape is modified, drawn or deleted. Save all the current shapes on the fig layout, which includes new
-    # modified, and deleted shapes.
+    
+    # Case 2: A shape is modified, drawn or deleted. Save all the current shapes on the fig layout
     if (
         any(["shapes" in key for key in relayout_data])
         and "shapes" in fig["layout"].keys()
     ):
         shapes = fig["layout"]["shapes"]
 
-    # Clear all annotation from the stores at the current slice,
-    # except for the hidden shapes (hidden shapes cannot be modified or deleted)
+    # Determine which source we're editing based on dropdown
+    target_source = "original" if mask_source == "annotations" else "sam3"
+
+    # Clear only annotations with the target source on current slice
     for a_class in all_annotation_class_store:
         if not a_class["is_visible"]:
             continue
         if img_idx in a_class["annotations"]:
-            del a_class["annotations"][img_idx]
-    # Add back each annotation on the current slice in each respective store.
+            # Keep shapes from OTHER sources, remove shapes from target source
+            a_class["annotations"][img_idx] = [
+                s for s in a_class["annotations"][img_idx] 
+                if s.get("source") != target_source
+            ]
+            if not a_class["annotations"][img_idx]:
+                del a_class["annotations"][img_idx]
+    
+    # Add shapes back, tagging them with the target source
     for shape in shapes:
-        for a_class in all_annotation_class_store:
-            if a_class["color"] == shape["line"]["color"]:
-                if img_idx in a_class["annotations"]:
-                    a_class["annotations"][img_idx].append(shape)
-                else:
-                    a_class["annotations"][img_idx] = [shape]
-                break
-    # redraw all annotations on the fig so the store is aligned with whats on the app
-    # ie: drawing with a hidden class hides the shape immediately
-    # ie: drawing with the first class pushes the shape to the back of the image imdediately
+        # Determine this shape's source
+        shape_source = shape.get("source")
+        
+        # If shape has no source, it's newly drawn - assign target_source
+        if shape_source is None:
+            shape["source"] = target_source
+            shape_source = target_source
+        
+        # Only add shapes that match the target source
+        # (shapes from other source were already preserved above)
+        if shape_source == target_source:
+            for a_class in all_annotation_class_store:
+                if a_class["color"] == shape["line"]["color"]:
+                    if img_idx in a_class["annotations"]:
+                        a_class["annotations"][img_idx].append(shape)
+                    else:
+                        a_class["annotations"][img_idx] = [shape]
+                    break
+    
+    # ✅ FIX: Redraw figure showing ONLY the target source (current view)
     fig = Patch()
     all_annotations = []
     for a in all_annotation_class_store:
         if a["is_visible"] and "annotations" in a and img_idx in a["annotations"]:
-            all_annotations += a["annotations"][img_idx]
+            # Filter to show only shapes matching the current mask source
+            filtered_shapes = [
+                s for s in a["annotations"][img_idx]
+                if s.get("source") == target_source
+            ]
+            all_annotations += filtered_shapes
     fig["layout"]["shapes"] = all_annotations
+    
     return all_annotation_class_store, annotation_store, fig
-
 
 @callback(
     Output(

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import traceback
 import uuid
@@ -23,6 +24,9 @@ from utils.data_utils import (
 )
 from utils.plot_utils import generate_notification
 
+# Configure logger
+logger = logging.getLogger("seg.segmentation")
+
 MODE = os.getenv("MODE", "")
 FLOW_NAME = os.getenv("FLOW_NAME", "")
 PREFECT_TAGS = os.getenv("PREFECT_TAGS", ["high-res-segmentation"])
@@ -46,6 +50,8 @@ mlflow_client = MLflowModelClient()
     State("model-parameters", "children"),
     State("model-list", "value"),
     State("job-name", "value"),
+    State("mask-source-selector", "value"),
+    State("sam3-masks-store", "data"),
     prevent_initial_call=True,
 )
 def run_train(
@@ -56,11 +62,13 @@ def run_train(
     model_parameter_container,
     model_name,
     job_name,
+    mask_source,
+    sam3_masks,
 ):
     """
     This callback collects parameters from the UI and submits a training job to Prefect.
     If the app is run from "dev" mode, then only a placeholder job_uid will be created.
-
+    Now supports using either manual annotations or SAM3 refined masks.
     """
     if n_clicks:
         model_parameters, parameter_errors = extract_parameters_from_html(
@@ -75,9 +83,21 @@ def run_train(
                 "Model parameters are not valid!",
             )
             return notification, no_update
-        mask_uri, num_classes, mask_error_message = tiled_masks.save_annotations_data(
-            global_store, all_annotations, image_uri
-        )
+
+        # Determine which mask to use based on user selection
+        if mask_source == "sam3" and sam3_masks:
+            logger.info("Using SAM3 refined masks for training")
+            mask_uri, num_classes, mask_error_message = (
+                tiled_masks.save_sam3_masks_data(sam3_masks, all_annotations, image_uri)
+            )
+        else:
+            logger.info("Using manual annotations for training")
+            mask_uri, num_classes, mask_error_message = (
+                tiled_masks.save_annotations_data(
+                    global_store, all_annotations, image_uri
+                )
+            )
+
         model_parameters["num_classes"] = num_classes
         model_parameters["network"] = model_name
 
@@ -100,7 +120,7 @@ def run_train(
         io_parameters["uid_retrieve"] = ""
         io_parameters["job_name"] = flow_run_name
 
-        # NEW: Add MLflow parameters
+        # Add MLflow parameters
         io_parameters["mlflow_uri"] = MLFLOW_URI
         io_parameters["mlflow_model"] = None
 
@@ -129,7 +149,7 @@ def run_train(
 
         if MODE == "dev":
             job_uid = str(uuid.uuid4())
-            job_message = f"Dev Mode: Job has been succesfully submitted with uid: {job_uid} and mask uri: {mask_uri}"
+            job_message = f"Dev Mode: Job has been succesfully submitted with uid: {job_uid} and mask uri: {mask_uri} (using {mask_source} masks)"
             notification_color = "indigo"
         else:
             try:
@@ -140,7 +160,7 @@ def run_train(
                     flow_run_name=flow_run_name,
                     tags=PREFECT_TAGS + ["train", image_uri],
                 )
-                job_message = f"Job has been succesfully submitted with uid: {job_uid} and mask uri: {mask_uri}"
+                job_message = f"Job has been succesfully submitted with uid: {job_uid} and mask uri: {mask_uri} (using {mask_source} masks)"
                 notification_color = "indigo"
             except Exception as e:
                 # Print the traceback to the console

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -85,10 +85,10 @@ def run_train(
             return notification, no_update
 
         # Determine which mask to use based on user selection
-        if mask_source == "sam3" and sam3_masks:
+        if mask_source == "sam3":
             logger.info("Using SAM3 refined masks for training")
             mask_uri, num_classes, mask_error_message = (
-                tiled_masks.save_sam3_masks_data(sam3_masks, all_annotations, image_uri)
+                tiled_masks.save_sam3_masks_data(global_store, all_annotations, image_uri)
             )
         else:
             logger.info("Using manual annotations for training")

--- a/callbacks/segmentation.py
+++ b/callbacks/segmentation.py
@@ -88,7 +88,9 @@ def run_train(
         if mask_source == "sam3":
             logger.info("Using SAM3 refined masks for training")
             mask_uri, num_classes, mask_error_message = (
-                tiled_masks.save_sam3_masks_data(global_store, all_annotations, image_uri)
+                tiled_masks.save_sam3_masks_data(
+                    global_store, all_annotations, image_uri
+                )
             )
         else:
             logger.info("Using manual annotations for training")

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -989,6 +989,7 @@ def create_infra_state_details(
     prefect_ready=False,
     prefect_worker_ready=False,
     mlflow_ready=False,
+    sam3_ready=False,  # ✅ NEW parameter
     timestamp=None,
 ):
     not_ready_icon = "pajamas:warning-solid"
@@ -1048,6 +1049,13 @@ def create_infra_state_details(
                     icon=ready_icon if mlflow_ready else not_ready_icon,
                     color=ready_color if mlflow_ready else not_ready_color,
                     id="mlflow-ready",
+                ),
+                # ✅ NEW: SAM3 status
+                create_infra_state_status(
+                    "SAM3 (Inference)",
+                    icon=ready_icon if sam3_ready else not_ready_icon,
+                    color=ready_color if sam3_ready else not_ready_color,
+                    id="sam3-ready",
                 ),
             ],
             p=0,

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -503,8 +503,15 @@ def layout():
                                     color="#00313C",
                                     style={"width": "100%"},
                                 ),
-                                # ADD SAM3 BUTTON HERE
-                                dmc.Space(h=3),
+                                # ===== SAM3 AI REFINEMENT SECTION =====
+                                dmc.Space(h=20),
+                                dmc.Divider(
+                                    label="SAM3 AI Refinement",
+                                    labelPosition="center",
+                                    variant="solid",
+                                    color="gray",
+                                ),
+                                dmc.Space(h=10),
                                 dmc.Button(
                                     "Refine by SAM3",
                                     id="refine-by-sam3",
@@ -512,9 +519,38 @@ def layout():
                                     color="indigo",
                                     style={"width": "100%"},
                                     leftIcon=DashIconify(icon="mdi:auto-fix", width=20),
-                                    disabled=True,  # ADD THIS - Start disabled until rectangle mode is selected
+                                    disabled=True,
                                 ),
-                                # END ADD
+                                dmc.Space(h=10),
+                                ControlItem(
+                                    "Training Mask Source",
+                                    "mask-source-label",
+                                    dmc.Select(
+                                        id="mask-source-selector",
+                                        data=[
+                                            {
+                                                "value": "annotations",
+                                                "label": "Manual Annotations",
+                                            },
+                                            {
+                                                "value": "sam3",
+                                                "label": "SAM3 Refined",
+                                                "disabled": True,
+                                            },
+                                        ],
+                                        value="annotations",
+                                        size="sm",
+                                        icon=DashIconify(icon="mdi:layers"),
+                                        styles={
+                                            "input": {"fontWeight": 500},
+                                        },
+                                    ),
+                                ),
+                                dcc.Store(
+                                    id="sam3-masks-store"
+                                ),  # Store SAM3 numpy masks
+                                dmc.Space(h=20),
+                                # ===== END SAM3 SECTION =====
                                 dmc.Modal(
                                     title="Data Management",
                                     id="data-management-modal",

--- a/components/control_bar.py
+++ b/components/control_bar.py
@@ -503,6 +503,18 @@ def layout():
                                     color="#00313C",
                                     style={"width": "100%"},
                                 ),
+                                # ADD SAM3 BUTTON HERE
+                                dmc.Space(h=3),
+                                dmc.Button(
+                                    "Refine by SAM3",
+                                    id="refine-by-sam3",
+                                    variant="outline",
+                                    color="indigo",
+                                    style={"width": "100%"},
+                                    leftIcon=DashIconify(icon="mdi:auto-fix", width=20),
+                                    disabled=True,  # ADD THIS - Start disabled until rectangle mode is selected
+                                ),
+                                # END ADD
                                 dmc.Modal(
                                     title="Data Management",
                                     id="data-management-modal",

--- a/constants.py
+++ b/constants.py
@@ -32,6 +32,7 @@ ANNOT_ICONS = {
     "submit": "formkit:submit",
     "parameters": "fluent-mdl2:machine-learning",
     "results": "entypo:download",
+    "sam3": "mdi:auto-fix",  # ADD THIS LINE
 }
 
 ANNOT_NOTIFICATION_MSGS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ torch==2.2.2
 torchvision==0.17.2
 transformers @ git+https://github.com/huggingface/transformers.git
 Pillow==12.0.0
+opencv-python-headless==4.10.0.84

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,8 @@ griffe >= 0.49.0, <1.0.0
 tiled_viewer==0.0.12
 mlflow==2.22.0
 mlex_utils[all] @ git+https://github.com/mlexchange/mlex_utils.git
+# SAM3 Dependencies
+torch==2.2.2
+torchvision==0.17.2
+transformers @ git+https://github.com/huggingface/transformers.git
+Pillow==12.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,5 @@ tiled_viewer==0.0.12
 mlflow==2.22.0
 mlex_utils[all] @ git+https://github.com/mlexchange/mlex_utils.git
 # SAM3 Dependencies
-torch==2.2.2
-torchvision==0.17.2
-transformers @ git+https://github.com/huggingface/transformers.git
 Pillow==12.0.0
 opencv-python-headless==4.10.0.84

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -315,14 +315,16 @@ class TiledMaskHandler:
         for annotation_class in all_annotations:
             filtered_class = annotation_class.copy()
             filtered_class["annotations"] = {}
-            
+
             for slice_idx, slice_annotations in annotation_class["annotations"].items():
-                manual_only = [s for s in slice_annotations if s.get("source") != "sam3"]
+                manual_only = [
+                    s for s in slice_annotations if s.get("source") != "sam3"
+                ]
                 if manual_only:
                     filtered_class["annotations"][slice_idx] = manual_only
-            
+
             filtered_annotations.append(filtered_class)
-        
+
         annotations = Annotations(filtered_annotations, image_shape)
         # ===== END OF ADDED BLOCK =====
         # TODO: Check sparse status, it may be worthwhile to store the mask as a sparse array

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -362,6 +362,101 @@ class TiledMaskHandler:
             "Annotations saved successfully.",
         )
 
+    # ===== ADD THIS NEW METHOD HERE =====
+    def save_sam3_masks_data(self, sam3_masks, all_annotations, trimmed_uri):
+        """
+        Save SAM3-refined masks to Tiled in the same format as manual annotations.
+
+        Args:
+            sam3_masks: Dict of {slice_idx: {"mask": 2D list, "image_shape": [h,w], "num_classes": n}}
+            all_annotations: Annotation class metadata (for labels and colors)
+            trimmed_uri: URI of the data source
+
+        Returns:
+            (mask_uri, num_classes, message)
+        """
+        if not sam3_masks:
+            return None, None, "No SAM3 masks to process."
+
+        # Get annotation classes info (labels and colors)
+        annotation_classes = {}
+        for idx, annotation_class in enumerate(all_annotations):
+            annotation_classes[str(idx)] = {
+                "label": annotation_class["label"],
+                "color": annotation_class["color"],
+            }
+
+        num_classes = len(annotation_classes)
+
+        # Get image shape from first mask
+        first_slice = list(sam3_masks.values())[0]
+        image_shape = tuple(first_slice["image_shape"])
+
+        # Convert stored masks back to numpy arrays
+        mask_list = []
+        mask_indices = []
+
+        for slice_idx_str, slice_data in sorted(
+            sam3_masks.items(), key=lambda x: int(x[0])
+        ):
+            mask_2d = np.array(slice_data["mask"], dtype=np.int8)
+            mask_list.append(mask_2d)
+            mask_indices.append(int(slice_idx_str))
+
+        # Stack into 3D array
+        try:
+            mask = np.stack(mask_list)
+        except ValueError:
+            return None, None, "Failed to stack SAM3 masks."
+
+        # Generate hash for SAM3 masks
+        import hashlib
+
+        import canonicaljson
+
+        hash_object = hashlib.md5()
+        hash_object.update(canonicaljson.encode_canonical_json(sam3_masks))
+        hash_object.update(canonicaljson.encode_canonical_json(annotation_classes))
+        sam3_masks_hash = hash_object.hexdigest()
+
+        # Create metadata
+        metadata = {
+            "project_name": trimmed_uri,
+            "data_uri": tiled_datasets.get_data_uri_by_trimmed_uri(trimmed_uri),
+            "image_shape": image_shape,
+            "mask_idx": mask_indices,
+            "classes": annotation_classes,
+            "annotations": {},  # SAM3 doesn't have vector annotations
+            "unlabeled_class_id": -1,
+            "mask_source": "sam3",  # Mark this as SAM3-generated
+        }
+
+        # Store the mask in Tiled under /username/<trimmed_uri>/<hash>/mask
+        container_keys = [USER_NAME] + trimmed_uri.strip("/").split("/")
+        last_container = self.mask_client
+        for key in container_keys:
+            if key not in last_container.keys():
+                last_container = last_container.create_container(key=key)
+            else:
+                last_container = last_container[key]
+
+        # Add metadata to container with hash as key
+        if sam3_masks_hash not in last_container.keys():
+            last_container = last_container.create_container(
+                key=sam3_masks_hash, metadata=metadata
+            )
+            mask = last_container.write_array(key="mask", array=mask)
+        else:
+            last_container = last_container[sam3_masks_hash]
+
+        return (
+            last_container.uri,
+            num_classes,
+            "SAM3 masks saved successfully.",
+        )
+
+    # ===== END OF NEW METHOD =====
+
 
 tiled_masks = TiledMaskHandler(
     mask_tiled_uri=MASK_TILED_URI,

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -403,9 +403,7 @@ class TiledMaskHandler:
             filtered_class["annotations"] = {}
 
             for slice_idx, slice_annotations in annotation_class["annotations"].items():
-                sam3_only = [
-                    s for s in slice_annotations if s.get("source") == "sam3"
-                ]
+                sam3_only = [s for s in slice_annotations if s.get("source") == "sam3"]
                 if sam3_only:
                     filtered_class["annotations"][slice_idx] = sam3_only
 
@@ -451,13 +449,12 @@ class TiledMaskHandler:
             mask = last_container.write_array(key="mask", array=mask)
         else:
             last_container = last_container[annotations_hash]
-        
+
         return (
             last_container.uri,
             len(annotation_classes),
             "SAM3 masks saved successfully.",
         )
-
 
 
 tiled_masks = TiledMaskHandler(

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -185,5 +185,275 @@ def prepare_masks_for_overlay(results):
         return tensor.unsqueeze(0) if len(tensor.shape) == 2 else tensor
 
 
+# ===== HELPER FUNCTIONS FOR CALLBACK REFACTORING =====
+
+def extract_rectangles_by_class(shapes, all_annotation_class_store):
+    """
+    Extract and group rectangle annotations by class color.
+    
+    Args:
+        shapes: List of shape annotations from figure
+        all_annotation_class_store: List of annotation class metadata
+        
+    Returns:
+        dict: {color: {"boxes": [[x0,y0,x1,y1], ...], "label": str}}
+    """
+    class_boxes = {}
+    
+    for shape in shapes:
+        if shape.get("type") == "rect":
+            color = shape.get("line", {}).get("color")
+            if color:
+                x0 = int(shape["x0"])
+                y0 = int(shape["y0"])
+                x1 = int(shape["x1"])
+                y1 = int(shape["y1"])
+                
+                # Ensure coordinates are in correct order
+                x_min = min(x0, x1)
+                x_max = max(x0, x1)
+                y_min = min(y0, y1)
+                y_max = max(y0, y1)
+                
+                box = [x_min, y_min, x_max, y_max]
+                
+                if color not in class_boxes:
+                    # Find label for this color
+                    label = "Unknown"
+                    for annotation_class in all_annotation_class_store:
+                        if annotation_class["color"] == color:
+                            label = annotation_class["label"]
+                            break
+                    class_boxes[color] = {"boxes": [], "label": label}
+                
+                class_boxes[color]["boxes"].append(box)
+    
+    return class_boxes
+
+
+def load_and_prepare_image(image_data):
+    """
+    Load image data and convert to PIL Image format.
+    
+    Args:
+        image_data: numpy array or other image format
+        
+    Returns:
+        PIL.Image: Converted image
+    """
+    if isinstance(image_data, np.ndarray):
+        # Normalize to 0-255 range
+        low = np.percentile(image_data.ravel(), 1)
+        high = np.percentile(image_data.ravel(), 99)
+        image_data_normalized = np.clip(
+            (image_data - low) / (high - low) * 255, 0, 255
+        ).astype(np.uint8)
+        
+        # Convert grayscale to RGB if needed
+        if len(image_data_normalized.shape) == 2:
+            image_data_normalized = np.stack([image_data_normalized] * 3, axis=-1)
+        
+        return Image.fromarray(image_data_normalized)
+    else:
+        return image_data
+
+
+def create_overlay_figure(overlay_image, image_shape):
+    """
+    Create Plotly figure patch with overlay image.
+    
+    Args:
+        overlay_image: PIL Image with overlaid masks
+        image_shape: Tuple (height, width) of original image
+        
+    Returns:
+        dict: Figure patch with overlay configuration
+    """
+    from dash import Patch
+    
+    # Convert overlay image to base64 for display
+    buffered = BytesIO()
+    overlay_image.save(buffered, format="PNG")
+    img_str = base64.b64encode(buffered.getvalue()).decode()
+    
+    fig_patch = Patch()
+    fig_patch["layout"]["images"] = [
+        {
+            "source": f"data:image/png;base64,{img_str}",
+            "xref": "x",
+            "yref": "y",
+            "x": 0,
+            "y": 0,
+            "sizex": image_shape[1],
+            "sizey": image_shape[0],
+            "sizing": "stretch",
+            "opacity": 0.5,
+            "layer": "above",
+        }
+    ]
+    
+    return fig_patch
+
+
+def convert_sam3_masks_to_numpy(
+    all_masks, all_colors, class_results_summary, all_annotation_class_store, image_shape
+):
+    """
+    Convert SAM3 masks to numpy array format matching manual annotations.
+    
+    Args:
+        all_masks: List of all SAM3 masks
+        all_colors: List of RGB colors for each mask
+        class_results_summary: List of strings like "'label': N mask(s)"
+        all_annotation_class_store: List of annotation class metadata
+        image_shape: Tuple (height, width)
+        
+    Returns:
+        np.ndarray: Mask array with shape (height, width) and class IDs
+    """
+    image_height, image_width = image_shape
+    
+    # Create a mapping from color to class_id and from label to class_id
+    color_to_class_id = {}
+    label_to_class_id = {}
+    for idx, annotation_class in enumerate(all_annotation_class_store):
+        color_to_class_id[annotation_class["color"]] = idx
+        label_to_class_id[annotation_class["label"]] = idx
+    
+    # Create numpy mask for this slice
+    slice_mask = np.full((image_height, image_width), fill_value=-1, dtype=np.int8)
+    
+    # Parse class_results_summary to get actual mask counts per class
+    # Format: "'Class1': 3 mask(s)", "'Class2': 5 mask(s)"
+    mask_idx = 0
+    for summary in class_results_summary:
+        # Extract label and count from summary string
+        # Example: "'Class1': 3 mask(s)" -> label="Class1", num_masks=3
+        parts = summary.split(":")
+        label = parts[0].strip().strip("'\"")
+        num_masks_str = parts[1].strip().split()[0]
+        num_masks_for_class = int(num_masks_str)
+        
+        class_id = label_to_class_id.get(label, -1)
+        if class_id == -1:
+            logger.warning(f"Could not find class_id for label '{label}'")
+            mask_idx += num_masks_for_class
+            continue
+        
+        logger.info(
+            f"Adding {num_masks_for_class} mask(s) for class '{label}' (id={class_id})"
+        )
+        
+        # Get all masks for this class
+        class_masks = all_masks[mask_idx : mask_idx + num_masks_for_class]
+        mask_idx += num_masks_for_class
+        
+        # Combine all masks for this class into the slice mask
+        for i, mask in enumerate(class_masks):
+            mask_np = mask.cpu().numpy() if isinstance(mask, torch.Tensor) else mask
+            # Handle both float and boolean masks
+            if mask_np.dtype == np.float32 or mask_np.dtype == np.float64:
+                mask_binary = mask_np > 0.5
+            else:
+                mask_binary = mask_np > 0
+            
+            pixels_added = np.sum(mask_binary)
+            logger.info(
+                f"  Mask {i+1}/{num_masks_for_class}: adding {pixels_added} pixels"
+            )
+            
+            # Set pixels where mask is True to the class_id
+            slice_mask[mask_binary] = class_id
+    
+    # Log final statistics
+    unique_values, counts = np.unique(slice_mask, return_counts=True)
+    logger.info("Final mask statistics:")
+    for val, count in zip(unique_values, counts):
+        if val == -1:
+            logger.info(f"  Unlabeled: {count} pixels")
+        else:
+            class_label = all_annotation_class_store[val]["label"]
+            logger.info(f"  Class {val} ({class_label}): {count} pixels")
+    
+    return slice_mask
+
+
+def hex_to_rgb(hex_color):
+    """
+    Convert hex color to RGB tuple.
+    
+    Args:
+        hex_color: Hex color string (e.g., "#FF0000" or "FF0000")
+        
+    Returns:
+        tuple: RGB values (r, g, b) where each is 0-255
+    """
+    hex_color = hex_color.lstrip("#")
+    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def segment_all_classes_with_sam3(
+    image_pil, class_boxes, sam3_client, threshold=0.5, mask_threshold=0.5
+):
+    """
+    Run SAM3 segmentation for all classes and collect results.
+    
+    Args:
+        image_pil: PIL Image to segment
+        class_boxes: Dict of {color: {"boxes": [[x0,y0,x1,y1], ...], "label": str}}
+        sam3_client: SAM3InferenceClient instance
+        threshold: Confidence threshold for SAM3
+        mask_threshold: Mask binarization threshold for SAM3
+        
+    Returns:
+        tuple: (all_masks, all_colors, class_results_summary)
+            - all_masks: List of all mask tensors
+            - all_colors: List of RGB tuples for each mask
+            - class_results_summary: List of result strings for each class
+        Returns (None, None, None) if no masks were generated
+    """
+    logger.info(f"Running SAM3 segmentation for {len(class_boxes)} class(es)...")
+    
+    all_masks = []
+    all_colors = []
+    class_results_summary = []
+
+    for color, data in class_boxes.items():
+        boxes = data["boxes"]
+        label = data["label"]
+
+        logger.info(f"Processing class '{label}' with {len(boxes)} box(es)...")
+
+        # Run SAM3 for this class
+        results = sam3_client.segment_with_boxes(
+            image_pil,
+            boxes,
+            threshold=threshold,
+            mask_threshold=mask_threshold,
+        )
+
+        if results is None or "masks" not in results or len(results["masks"]) == 0:
+            logger.warning(f"SAM3 failed for class '{label}'")
+            continue
+
+        num_masks = len(results["masks"])
+        logger.info(f"✓ Class '{label}': generated {num_masks} mask(s)")
+
+        rgb_color = hex_to_rgb(color)
+
+        # Add masks and colors for this class
+        all_masks.extend(results["masks"])
+        all_colors.extend([rgb_color] * num_masks)
+
+        class_results_summary.append(f"'{label}': {num_masks} mask(s)")
+
+    if not all_masks:
+        logger.error("No masks generated for any class")
+        return None, None, None
+    
+    logger.info(f"✓ Total masks generated: {len(all_masks)}")
+    return all_masks, all_colors, class_results_summary
+
+
 # Global client instance
 sam3_segmenter = SAM3InferenceClient()

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -3,11 +3,11 @@ import logging
 import os
 from io import BytesIO
 
+import cv2
 import numpy as np
 import requests
 import torch
 from PIL import Image
-import cv2
 
 logger = logging.getLogger("seg.sam3_utils")
 
@@ -464,67 +464,69 @@ def segment_all_classes_with_sam3(
 def masks_to_plotly_polygons(masks, class_color, min_area=100, epsilon_factor=0.002):
     """
     Convert SAM3 masks to Plotly polygon shapes.
-    
+
     Args:
         masks: torch.Tensor [num_masks, H, W] or list of masks
         class_color: Hex color string (e.g., "#FF0000")
         min_area: Minimum contour area in pixels
         epsilon_factor: Polygon simplification (0.001-0.01, lower=more detail)
-    
+
     Returns:
         List of Plotly shape dicts for fig["layout"]["shapes"]
     """
     polygons = []
-    
+
     # Convert to numpy
     if isinstance(masks, torch.Tensor):
         masks_np = masks.cpu().numpy().astype(np.uint8)
     else:
         masks_np = np.array(masks).astype(np.uint8)
-    
+
     if len(masks_np.shape) == 2:
         masks_np = masks_np[np.newaxis, ...]
-    
+
     for mask in masks_np:
         # Find contours
         contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        
+
         if not contours:
             continue
-        
+
         # Get largest contour
         contour = max(contours, key=cv2.contourArea)
-        
+
         if cv2.contourArea(contour) < min_area:
             continue
-        
+
         # Simplify polygon
         perimeter = cv2.arcLength(contour, True)
         epsilon = epsilon_factor * perimeter
         approx = cv2.approxPolyDP(contour, epsilon, True)
-        
+
         points = approx.squeeze().tolist()
         if not isinstance(points[0], list):
             points = [points]
-        
+
         if len(points) < 3:
             continue
-        
+
         # Build SVG path: M x0,y0 L x1,y1 ... Z
         path_parts = [f"M {points[0][0]},{points[0][1]}"]
         for x, y in points[1:]:
             path_parts.append(f"L {x},{y}")
         path_parts.append("Z")
-        
-        polygons.append({
-            "type": "path",
-            "path": " ".join(path_parts),
-            "fillcolor": class_color,
-            "fillrule": "evenodd",
-            "line": {"color": class_color},
-            "editable": True,
-        })
-    
+
+        polygons.append(
+            {
+                "type": "path",
+                "path": " ".join(path_parts),
+                "fillcolor": class_color,
+                "fillrule": "evenodd",
+                "line": {"color": class_color},
+                "editable": True,
+            }
+        )
+
     return polygons
 
 
@@ -533,7 +535,7 @@ def segment_all_classes_to_polygons(
 ):
     """
     Run SAM3 and return BOTH polygons and masks.
-    
+
     Returns:
         Tuple of (all_polygons, all_masks, all_colors, class_results_summary) or (None, None, None, None)
         - all_polygons: List of Plotly shape dicts (for UI display)
@@ -542,44 +544,47 @@ def segment_all_classes_to_polygons(
         - class_results_summary: List of result strings
     """
     logger.info(f"Generating polygons for {len(class_boxes)} class(es)...")
-    
+
     all_polygons = []
     all_masks = []
     all_colors = []
     class_results_summary = []
-    
+
     for color, data in class_boxes.items():
         boxes = data["boxes"]
         label = data["label"]
-        
+
         logger.info(f"Processing '{label}' ({len(boxes)} box(es))...")
-        
+
         results = sam3_client.segment_with_boxes(
             image_pil, boxes, threshold=threshold, mask_threshold=mask_threshold
         )
-        
+
         if results is None or "masks" not in results or len(results["masks"]) == 0:
             logger.warning(f"SAM3 failed for '{label}'")
             continue
-        
+
         # Convert to polygons for UI
         class_polygons = masks_to_plotly_polygons(results["masks"], class_color=color)
-        
+
         # Keep original masks for Tiled export
         num_masks = len(results["masks"])
-        
-        logger.info(f"✓ '{label}': {len(class_polygons)} polygon(s), {num_masks} mask(s)")
-        
+
+        logger.info(
+            f"✓ '{label}': {len(class_polygons)} polygon(s), {num_masks} mask(s)"
+        )
+
         all_polygons.extend(class_polygons)
         all_masks.extend(results["masks"])
         all_colors.extend([color] * num_masks)
         class_results_summary.append(f"'{label}': {len(class_polygons)} polygon(s)")
-    
+
     if not all_polygons:
         return None, None, None, None
-    
+
     logger.info(f"✓ Total: {len(all_polygons)} polygon(s), {len(all_masks)} mask(s)")
     return all_polygons, all_masks, all_colors, class_results_summary
+
 
 # Global client instance
 sam3_segmenter = SAM3InferenceClient()

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -393,5 +393,20 @@ def segment_all_classes_to_polygons(
     return all_polygons, all_masks, all_colors, class_results_summary
 
 
+def check_sam3_ready():
+    """Check if SAM3 inference endpoint is reachable and healthy"""
+    try:
+        health_url = SAM3_INFERENCE_URL.replace("/invocations", "/health")
+        response = requests.get(health_url, timeout=5)
+
+        if response.status_code == 200:
+            data = response.json()
+            # Check if model is loaded and status is healthy
+            return data.get("status") == "healthy"
+        return False
+    except Exception:
+        return False
+
+
 # Global client instance
 sam3_segmenter = SAM3InferenceClient()

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -1,8 +1,9 @@
-import os
 import logging
-import torch
-import numpy as np
+import os
+
 import matplotlib
+import numpy as np
+import torch
 from PIL import Image
 from transformers import Sam3Model, Sam3Processor
 
@@ -14,10 +15,12 @@ HF_TOKEN = os.getenv("HF_TOKEN")
 if HF_TOKEN:
     try:
         from huggingface_hub import login
+
         login(token=HF_TOKEN)
         logger.info("Successfully authenticated with Hugging Face")
     except Exception as e:
         logger.warning(f"Failed to authenticate with Hugging Face: {e}")
+
 
 # Get device - prefer CUDA, fall back to MPS, then CPU
 def get_device():
@@ -26,6 +29,7 @@ def get_device():
     elif torch.backends.mps.is_available():
         return "mps"
     return "cpu"
+
 
 DEVICE = get_device()
 SAM_MODEL_NAME = os.getenv("SAM_MODEL_NAME", "facebook/sam3")
@@ -39,7 +43,7 @@ class SAM3Segmenter:
     Wrapper for SAM3 segmentation with support for bbox and point prompts.
     Model is loaded lazily on first use to prevent worker timeout.
     """
-    
+
     def __init__(self):
         self.device = DEVICE
         self.model = None
@@ -47,35 +51,35 @@ class SAM3Segmenter:
         self._loading = False
         self._load_failed = False
         logger.info("SAM3Segmenter initialized (model will load on first use)")
-        
+
     def load_model(self):
         """Load SAM3 model and processor (lazy loading on first use)"""
         if self.model is not None:
             return True
-        
+
         if self._load_failed:
             logger.error("Previous model load failed, skipping retry")
             return False
-        
+
         if self._loading:
             logger.warning("Model is already being loaded by another request")
             return False
-            
+
         try:
             self._loading = True
             logger.info("=" * 80)
             logger.info(f"Loading SAM3 model on {self.device}...")
             logger.info("This may take 30-60 seconds on first load...")
             logger.info("=" * 80)
-            
+
             self.model = Sam3Model.from_pretrained(SAM_MODEL_NAME).to(self.device)
             self.processor = Sam3Processor.from_pretrained(SAM_MODEL_NAME)
-            
+
             logger.info("=" * 80)
             logger.info("SAM3 model loaded successfully!")
             logger.info("=" * 80)
             return True
-            
+
         except Exception as e:
             logger.error("=" * 80)
             logger.error(f"Error loading SAM3 model: {e}", exc_info=True)
@@ -84,21 +88,21 @@ class SAM3Segmenter:
             self.processor = None
             self._load_failed = True
             return False
-            
+
         finally:
             self._loading = False
-    
+
     def segment_with_boxes(self, image, boxes, threshold=0.5, mask_threshold=0.5):
         """
         Segment using bounding boxes
-        
+
         Args:
             image: PIL Image
             boxes: list of [x1, y1, x2, y2] in pixel coordinates
             threshold: confidence threshold for mask selection
             mask_threshold: threshold for binarizing masks
-            
-        Returns: 
+
+        Returns:
             dict with 'masks', 'scores', 'boxes' keys
             - masks: list of torch.Tensor masks, one per input box
             - scores: list of confidence scores
@@ -107,7 +111,7 @@ class SAM3Segmenter:
         logger.info("=" * 80)
         logger.info("=== SAM3 segment_with_boxes called ===")
         logger.info("=" * 80)
-        
+
         # === DETAILED INPUT LOGGING ===
         logger.info("INPUT DETAILS:")
         logger.info(f"  Image type: {type(image)}")
@@ -125,27 +129,27 @@ class SAM3Segmenter:
             logger.info(f"           Size: {width}x{height} pixels")
             logger.info(f"           Area: {width * height} pixels")
         logger.info("=" * 80)
-        
+
         if not self.load_model():
             logger.error("Failed to load model")
             return None
-            
+
         try:
             logger.info("STEP 1: Processing inputs...")
-            
+
             # Create labels list - one label per box (all positive)
             box_labels = [1] * len(boxes)
-            
+
             logger.info(f"  Input boxes: {boxes}")
             logger.info(f"  Box labels: {box_labels}")
-            
+
             inputs = self.processor(
                 images=image,
                 input_boxes=[boxes],  # Wrap in list for batch dimension
                 input_boxes_labels=[box_labels],  # One label per box
-                return_tensors="pt"
+                return_tensors="pt",
             ).to(self.device)
-            
+
             logger.info(f"  Processor created inputs with keys: {list(inputs.keys())}")
             if "original_sizes" in inputs:
                 logger.info(f"  Original sizes: {inputs['original_sizes']}")
@@ -153,46 +157,48 @@ class SAM3Segmenter:
                 logger.info(f"  Pixel values shape: {inputs['pixel_values'].shape}")
             if "input_boxes" in inputs:
                 logger.info(f"  Input boxes shape: {inputs['input_boxes'].shape}")
-            
+
             logger.info("STEP 2: Running SAM3 inference...")
-            
+
             with torch.no_grad():
                 outputs = self.model(**inputs)
-            
+
             logger.info(f"  Model outputs type: {type(outputs)}")
-            if hasattr(outputs, 'keys'):
+            if hasattr(outputs, "keys"):
                 logger.info(f"  Output keys: {list(outputs.keys())}")
-            
+
             logger.info("STEP 3: Post-processing masks...")
-            
+
             # Post-process to get masks
             results = self.processor.post_process_instance_segmentation(
                 outputs,
                 threshold=threshold,
                 mask_threshold=mask_threshold,
-                target_sizes=inputs.get("original_sizes").tolist()
-            )[0]  # Get first (and only) batch item
-            
+                target_sizes=inputs.get("original_sizes").tolist(),
+            )[
+                0
+            ]  # Get first (and only) batch item
+
             logger.info(f"  Results type: {type(results)}")
             logger.info(f"  Results keys: {list(results.keys())}")
-            
+
             # === DETAILED OUTPUT LOGGING ===
             logger.info("=" * 80)
             logger.info("OUTPUT DETAILS:")
-            
-            if 'masks' in results and len(results['masks']) > 0:
-                masks = results['masks']
+
+            if "masks" in results and len(results["masks"]) > 0:
+                masks = results["masks"]
                 logger.info("=" * 80)
                 logger.info(f"✓ Successfully generated {len(masks)} mask(s)")
                 logger.info("=" * 80)
-                
+
                 return results
             else:
                 logger.warning("=" * 80)
                 logger.warning("✗ No masks generated!")
                 logger.warning("=" * 80)
                 return None
-                
+
         except Exception as e:
             logger.error("=" * 80)
             logger.error(f"✗ Error in box segmentation: {e}", exc_info=True)
@@ -203,14 +209,14 @@ class SAM3Segmenter:
 def overlay_masks(image, masks, colors=None, opacity=0.5):
     """
     Overlay masks on image with different colors
-    
+
     Args:
         image: PIL Image
         masks: torch.Tensor of shape [num_masks, H, W] or list of masks
-        colors: Optional list of RGB tuples (one per mask). If only one color 
+        colors: Optional list of RGB tuples (one per mask). If only one color
                 provided, it will be used for all masks.
         opacity: Float between 0 and 1 for mask transparency
-    
+
     Returns:
         PIL Image with masks overlaid
     """
@@ -220,29 +226,26 @@ def overlay_masks(image, masks, colors=None, opacity=0.5):
     logger.info(f"  Masks type: {type(masks)}")
     logger.info(f"  Masks shape: {masks.shape if hasattr(masks, 'shape') else 'N/A'}")
     logger.info(f"  Opacity: {opacity}")
-    
+
     image = image.convert("RGBA")
-    
+
     # Convert masks to numpy
     if isinstance(masks, torch.Tensor):
         masks_np = masks.cpu().numpy()
     else:
         masks_np = np.array(masks)
-    
+
     # Ensure masks are in the right shape [num_masks, H, W]
     if len(masks_np.shape) == 2:
         masks_np = masks_np[np.newaxis, ...]  # Add batch dimension
-    
+
     n_masks = masks_np.shape[0]
     logger.info(f"  Number of masks: {n_masks}")
-    
+
     # Generate colors if not provided
     if colors is None:
         cmap = matplotlib.colormaps.get_cmap("rainbow").resampled(n_masks)
-        colors = [
-            tuple(int(c * 255) for c in cmap(i)[:3])
-            for i in range(n_masks)
-        ]
+        colors = [tuple(int(c * 255) for c in cmap(i)[:3]) for i in range(n_masks)]
         logger.info(f"  Generated {len(colors)} rainbow colors")
     else:
         # If only one color provided but multiple masks, repeat it
@@ -250,30 +253,30 @@ def overlay_masks(image, masks, colors=None, opacity=0.5):
             colors = colors * n_masks
             logger.info(f"  Repeated single color {n_masks} times: {colors[0]}")
         logger.info(f"  Using {len(colors)} colors")
-    
+
     logger.info(f"  Overlaying {n_masks} masks with {len(colors)} colors")
-    
+
     # Apply each mask
     for i, (mask, color) in enumerate(zip(masks_np, colors)):
         # Convert to uint8 binary mask
         mask_binary = (mask > 0).astype(np.uint8) * 255
         true_pixels = (mask > 0).sum()
-        
+
         logger.info(f"  Mask {i}: color={color}, true_pixels={true_pixels}")
-        
+
         # Create PIL image from mask
-        mask_img = Image.fromarray(mask_binary, mode='L')
-        
+        mask_img = Image.fromarray(mask_binary, mode="L")
+
         # Create colored overlay
         overlay = Image.new("RGBA", image.size, color + (0,))
-        
+
         # Set alpha channel based on mask with specified opacity
         alpha = mask_img.point(lambda v: int(v * opacity))
         overlay.putalpha(alpha)
-        
+
         # Composite onto image
         image = Image.alpha_composite(image, overlay)
-    
+
     logger.info("✓ Overlay complete")
     logger.info("=" * 80)
     return image
@@ -283,18 +286,18 @@ def prepare_masks_for_overlay(results):
     """
     Prepare masks from SAM3 results for overlay
     Converts torch tensors to a stacked tensor if needed
-    
+
     Args:
         results: Dict with 'masks' key containing list of masks
-    
+
     Returns:
         torch.Tensor of shape [num_masks, H, W]
     """
-    if results is None or 'masks' not in results:
+    if results is None or "masks" not in results:
         return None
-    
-    masks = results['masks']
-    
+
+    masks = results["masks"]
+
     if isinstance(masks, torch.Tensor):
         # Already a tensor, ensure 3D shape
         if len(masks.shape) == 2:

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -1,0 +1,316 @@
+import os
+import logging
+import torch
+import numpy as np
+import matplotlib
+from PIL import Image
+from transformers import Sam3Model, Sam3Processor
+
+# Configure logger
+logger = logging.getLogger("seg.sam3_utils")
+
+# Authenticate with Hugging Face if token is provided
+HF_TOKEN = os.getenv("HF_TOKEN")
+if HF_TOKEN:
+    try:
+        from huggingface_hub import login
+        login(token=HF_TOKEN)
+        logger.info("Successfully authenticated with Hugging Face")
+    except Exception as e:
+        logger.warning(f"Failed to authenticate with Hugging Face: {e}")
+
+# Get device - prefer CUDA, fall back to MPS, then CPU
+def get_device():
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+DEVICE = get_device()
+SAM_MODEL_NAME = os.getenv("SAM_MODEL_NAME", "facebook/sam3")
+
+logger.info(f"SAM using device: {DEVICE}")
+logger.info(f"SAM model name: {SAM_MODEL_NAME}")
+
+
+class SAM3Segmenter:
+    """
+    Wrapper for SAM3 segmentation with support for bbox and point prompts.
+    Model is loaded lazily on first use to prevent worker timeout.
+    """
+    
+    def __init__(self):
+        self.device = DEVICE
+        self.model = None
+        self.processor = None
+        self._loading = False
+        self._load_failed = False
+        logger.info("SAM3Segmenter initialized (model will load on first use)")
+        
+    def load_model(self):
+        """Load SAM3 model and processor (lazy loading on first use)"""
+        if self.model is not None:
+            return True
+        
+        if self._load_failed:
+            logger.error("Previous model load failed, skipping retry")
+            return False
+        
+        if self._loading:
+            logger.warning("Model is already being loaded by another request")
+            return False
+            
+        try:
+            self._loading = True
+            logger.info("=" * 80)
+            logger.info(f"Loading SAM3 model on {self.device}...")
+            logger.info("This may take 30-60 seconds on first load...")
+            logger.info("=" * 80)
+            
+            self.model = Sam3Model.from_pretrained(SAM_MODEL_NAME).to(self.device)
+            self.processor = Sam3Processor.from_pretrained(SAM_MODEL_NAME)
+            
+            logger.info("=" * 80)
+            logger.info("SAM3 model loaded successfully!")
+            logger.info("=" * 80)
+            return True
+            
+        except Exception as e:
+            logger.error("=" * 80)
+            logger.error(f"Error loading SAM3 model: {e}", exc_info=True)
+            logger.error("=" * 80)
+            self.model = None
+            self.processor = None
+            self._load_failed = True
+            return False
+            
+        finally:
+            self._loading = False
+    
+    def segment_with_boxes(self, image, boxes, threshold=0.5, mask_threshold=0.5):
+        """
+        Segment using bounding boxes
+        
+        Args:
+            image: PIL Image
+            boxes: list of [x1, y1, x2, y2] in pixel coordinates
+            threshold: confidence threshold for mask selection
+            mask_threshold: threshold for binarizing masks
+            
+        Returns: 
+            dict with 'masks', 'scores', 'boxes' keys
+            - masks: list of torch.Tensor masks, one per input box
+            - scores: list of confidence scores
+            - boxes: list of refined bounding boxes
+        """
+        logger.info("=" * 80)
+        logger.info("=== SAM3 segment_with_boxes called ===")
+        logger.info("=" * 80)
+        
+        # === DETAILED INPUT LOGGING ===
+        logger.info("INPUT DETAILS:")
+        logger.info(f"  Image type: {type(image)}")
+        logger.info(f"  Image size: {image.size if hasattr(image, 'size') else 'N/A'}")
+        logger.info(f"  Image mode: {image.mode if hasattr(image, 'mode') else 'N/A'}")
+        logger.info(f"  Threshold: {threshold}")
+        logger.info(f"  Mask threshold: {mask_threshold}")
+        logger.info(f"  Number of boxes: {len(boxes)}")
+        logger.info(f"  Bounding boxes:")
+        for i, box in enumerate(boxes):
+            x1, y1, x2, y2 = box
+            width = x2 - x1
+            height = y2 - y1
+            logger.info(f"    Box {i}: [x1={x1}, y1={y1}, x2={x2}, y2={y2}]")
+            logger.info(f"           Size: {width}x{height} pixels")
+            logger.info(f"           Area: {width * height} pixels")
+        logger.info("=" * 80)
+        
+        if not self.load_model():
+            logger.error("Failed to load model")
+            return None
+            
+        try:
+            logger.info("STEP 1: Processing inputs...")
+            
+            # Create labels list - one label per box (all positive)
+            box_labels = [1] * len(boxes)
+            
+            logger.info(f"  Input boxes: {boxes}")
+            logger.info(f"  Box labels: {box_labels}")
+            
+            inputs = self.processor(
+                images=image,
+                input_boxes=[boxes],  # Wrap in list for batch dimension
+                input_boxes_labels=[box_labels],  # One label per box
+                return_tensors="pt"
+            ).to(self.device)
+            
+            logger.info(f"  Processor created inputs with keys: {list(inputs.keys())}")
+            if "original_sizes" in inputs:
+                logger.info(f"  Original sizes: {inputs['original_sizes']}")
+            if "pixel_values" in inputs:
+                logger.info(f"  Pixel values shape: {inputs['pixel_values'].shape}")
+            if "input_boxes" in inputs:
+                logger.info(f"  Input boxes shape: {inputs['input_boxes'].shape}")
+            
+            logger.info("STEP 2: Running SAM3 inference...")
+            
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+            
+            logger.info(f"  Model outputs type: {type(outputs)}")
+            if hasattr(outputs, 'keys'):
+                logger.info(f"  Output keys: {list(outputs.keys())}")
+            
+            logger.info("STEP 3: Post-processing masks...")
+            
+            # Post-process to get masks
+            results = self.processor.post_process_instance_segmentation(
+                outputs,
+                threshold=threshold,
+                mask_threshold=mask_threshold,
+                target_sizes=inputs.get("original_sizes").tolist()
+            )[0]  # Get first (and only) batch item
+            
+            logger.info(f"  Results type: {type(results)}")
+            logger.info(f"  Results keys: {list(results.keys())}")
+            
+            # === DETAILED OUTPUT LOGGING ===
+            logger.info("=" * 80)
+            logger.info("OUTPUT DETAILS:")
+            
+            if 'masks' in results and len(results['masks']) > 0:
+                masks = results['masks']
+                logger.info("=" * 80)
+                logger.info(f"✓ Successfully generated {len(masks)} mask(s)")
+                logger.info("=" * 80)
+                
+                return results
+            else:
+                logger.warning("=" * 80)
+                logger.warning("✗ No masks generated!")
+                logger.warning("=" * 80)
+                return None
+                
+        except Exception as e:
+            logger.error("=" * 80)
+            logger.error(f"✗ Error in box segmentation: {e}", exc_info=True)
+            logger.error("=" * 80)
+            return None
+
+
+def overlay_masks(image, masks, colors=None, opacity=0.5):
+    """
+    Overlay masks on image with different colors
+    
+    Args:
+        image: PIL Image
+        masks: torch.Tensor of shape [num_masks, H, W] or list of masks
+        colors: Optional list of RGB tuples (one per mask). If only one color 
+                provided, it will be used for all masks.
+        opacity: Float between 0 and 1 for mask transparency
+    
+    Returns:
+        PIL Image with masks overlaid
+    """
+    logger.info("=" * 80)
+    logger.info("=== overlay_masks called ===")
+    logger.info(f"  Image size: {image.size}")
+    logger.info(f"  Masks type: {type(masks)}")
+    logger.info(f"  Masks shape: {masks.shape if hasattr(masks, 'shape') else 'N/A'}")
+    logger.info(f"  Opacity: {opacity}")
+    
+    image = image.convert("RGBA")
+    
+    # Convert masks to numpy
+    if isinstance(masks, torch.Tensor):
+        masks_np = masks.cpu().numpy()
+    else:
+        masks_np = np.array(masks)
+    
+    # Ensure masks are in the right shape [num_masks, H, W]
+    if len(masks_np.shape) == 2:
+        masks_np = masks_np[np.newaxis, ...]  # Add batch dimension
+    
+    n_masks = masks_np.shape[0]
+    logger.info(f"  Number of masks: {n_masks}")
+    
+    # Generate colors if not provided
+    if colors is None:
+        cmap = matplotlib.colormaps.get_cmap("rainbow").resampled(n_masks)
+        colors = [
+            tuple(int(c * 255) for c in cmap(i)[:3])
+            for i in range(n_masks)
+        ]
+        logger.info(f"  Generated {len(colors)} rainbow colors")
+    else:
+        # If only one color provided but multiple masks, repeat it
+        if len(colors) == 1 and n_masks > 1:
+            colors = colors * n_masks
+            logger.info(f"  Repeated single color {n_masks} times: {colors[0]}")
+        logger.info(f"  Using {len(colors)} colors")
+    
+    logger.info(f"  Overlaying {n_masks} masks with {len(colors)} colors")
+    
+    # Apply each mask
+    for i, (mask, color) in enumerate(zip(masks_np, colors)):
+        # Convert to uint8 binary mask
+        mask_binary = (mask > 0).astype(np.uint8) * 255
+        true_pixels = (mask > 0).sum()
+        
+        logger.info(f"  Mask {i}: color={color}, true_pixels={true_pixels}")
+        
+        # Create PIL image from mask
+        mask_img = Image.fromarray(mask_binary, mode='L')
+        
+        # Create colored overlay
+        overlay = Image.new("RGBA", image.size, color + (0,))
+        
+        # Set alpha channel based on mask with specified opacity
+        alpha = mask_img.point(lambda v: int(v * opacity))
+        overlay.putalpha(alpha)
+        
+        # Composite onto image
+        image = Image.alpha_composite(image, overlay)
+    
+    logger.info("✓ Overlay complete")
+    logger.info("=" * 80)
+    return image
+
+
+def prepare_masks_for_overlay(results):
+    """
+    Prepare masks from SAM3 results for overlay
+    Converts torch tensors to a stacked tensor if needed
+    
+    Args:
+        results: Dict with 'masks' key containing list of masks
+    
+    Returns:
+        torch.Tensor of shape [num_masks, H, W]
+    """
+    if results is None or 'masks' not in results:
+        return None
+    
+    masks = results['masks']
+    
+    if isinstance(masks, torch.Tensor):
+        # Already a tensor, ensure 3D shape
+        if len(masks.shape) == 2:
+            return masks.unsqueeze(0)  # Add batch dimension
+        return masks
+    elif isinstance(masks, list):
+        # Stack list of tensors
+        return torch.stack(masks)
+    else:
+        # Convert to tensor
+        tensor = torch.tensor(masks)
+        if len(tensor.shape) == 2:
+            return tensor.unsqueeze(0)
+        return tensor
+
+
+# Global instance - model will load lazily on first use
+sam3_segmenter = SAM3Segmenter()
+logger.info("Global sam3_segmenter instance created (lazy loading enabled)")

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -1,231 +1,128 @@
+import base64
 import logging
 import os
+from io import BytesIO
 
-import matplotlib
 import numpy as np
+import requests
 import torch
 from PIL import Image
-from transformers import Sam3Model, Sam3Processor
 
-# Configure logger
 logger = logging.getLogger("seg.sam3_utils")
 
-# Authenticate with Hugging Face if token is provided
-HF_TOKEN = os.getenv("HF_TOKEN")
-if HF_TOKEN:
-    try:
-        from huggingface_hub import login
+# Configuration from environment
+SAM3_INFERENCE_URL = os.getenv(
+    "SAM3_INFERENCE_URL", "http://sam3-inference:5001/invocations"
+)
+SAM3_TIMEOUT = int(os.getenv("SAM3_TIMEOUT", "120"))
 
-        login(token=HF_TOKEN)
-        logger.info("Successfully authenticated with Hugging Face")
-    except Exception as e:
-        logger.warning(f"Failed to authenticate with Hugging Face: {e}")
+logger.info(f"SAM3 Client initialized: {SAM3_INFERENCE_URL}")
 
 
-# Get device - prefer CUDA, fall back to MPS, then CPU
-def get_device():
-    if torch.cuda.is_available():
-        return "cuda"
-    elif torch.backends.mps.is_available():
-        return "mps"
-    return "cpu"
+class SAM3InferenceClient:
+    """Client for SAM3 inference service"""
 
+    def __init__(self, inference_url=SAM3_INFERENCE_URL, timeout=SAM3_TIMEOUT):
+        self.inference_url = inference_url
+        self.timeout = timeout
+        logger.info(f"SAM3 API endpoint: {inference_url} (timeout: {timeout}s)")
 
-DEVICE = get_device()
-SAM_MODEL_NAME = os.getenv("SAM_MODEL_NAME", "facebook/sam3")
+    def _encode_image(self, image):
+        """Encode PIL Image to base64 string"""
+        buffer = BytesIO()
+        image.save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-logger.info(f"SAM using device: {DEVICE}")
-logger.info(f"SAM model name: {SAM_MODEL_NAME}")
-
-
-class SAM3Segmenter:
-    """
-    Wrapper for SAM3 segmentation with support for bbox and point prompts.
-    Model is loaded lazily on first use to prevent worker timeout.
-    """
-
-    def __init__(self):
-        self.device = DEVICE
-        self.model = None
-        self.processor = None
-        self._loading = False
-        self._load_failed = False
-        logger.info("SAM3Segmenter initialized (model will load on first use)")
-
-    def load_model(self):
-        """Load SAM3 model and processor (lazy loading on first use)"""
-        if self.model is not None:
-            return True
-
-        if self._load_failed:
-            logger.error("Previous model load failed, skipping retry")
-            return False
-
-        if self._loading:
-            logger.warning("Model is already being loaded by another request")
-            return False
-
-        try:
-            self._loading = True
-            logger.info("=" * 80)
-            logger.info(f"Loading SAM3 model on {self.device}...")
-            logger.info("This may take 30-60 seconds on first load...")
-            logger.info("=" * 80)
-
-            self.model = Sam3Model.from_pretrained(SAM_MODEL_NAME).to(self.device)
-            self.processor = Sam3Processor.from_pretrained(SAM_MODEL_NAME)
-
-            logger.info("=" * 80)
-            logger.info("SAM3 model loaded successfully!")
-            logger.info("=" * 80)
-            return True
-
-        except Exception as e:
-            logger.error("=" * 80)
-            logger.error(f"Error loading SAM3 model: {e}", exc_info=True)
-            logger.error("=" * 80)
-            self.model = None
-            self.processor = None
-            self._load_failed = True
-            return False
-
-        finally:
-            self._loading = False
+    def _decode_mask(self, encoded_mask):
+        """Decode base64 string to numpy boolean mask"""
+        mask_bytes = base64.b64decode(encoded_mask)
+        mask_img = Image.open(BytesIO(mask_bytes))
+        return np.array(mask_img) > 0
 
     def segment_with_boxes(self, image, boxes, threshold=0.5, mask_threshold=0.5):
         """
-        Segment using bounding boxes
+        Segment image using bounding box prompts
 
         Args:
             image: PIL Image
-            boxes: list of [x1, y1, x2, y2] in pixel coordinates
-            threshold: confidence threshold for mask selection
-            mask_threshold: threshold for binarizing masks
+            boxes: List of [x1, y1, x2, y2] bounding boxes
+            threshold: Confidence threshold (0.0-1.0)
+            mask_threshold: Mask binarization threshold (0.0-1.0)
 
         Returns:
-            dict with 'masks', 'scores', 'boxes' keys
-            - masks: list of torch.Tensor masks, one per input box
-            - scores: list of confidence scores
-            - boxes: list of refined bounding boxes
+            dict: {'masks': [tensor, ...], 'scores': [float, ...]} or None
         """
-        logger.info("=" * 80)
-        logger.info("=== SAM3 segment_with_boxes called ===")
-        logger.info("=" * 80)
+        logger.info(f"Segmenting {len(boxes)} boxes on {image.size} image")
 
-        # === DETAILED INPUT LOGGING ===
-        logger.info("INPUT DETAILS:")
-        logger.info(f"  Image type: {type(image)}")
-        logger.info(f"  Image size: {image.size if hasattr(image, 'size') else 'N/A'}")
-        logger.info(f"  Image mode: {image.mode if hasattr(image, 'mode') else 'N/A'}")
-        logger.info(f"  Threshold: {threshold}")
-        logger.info(f"  Mask threshold: {mask_threshold}")
-        logger.info(f"  Number of boxes: {len(boxes)}")
-        logger.info(f"  Bounding boxes:")
-        for i, box in enumerate(boxes):
-            x1, y1, x2, y2 = box
-            width = x2 - x1
-            height = y2 - y1
-            logger.info(f"    Box {i}: [x1={x1}, y1={y1}, x2={x2}, y2={y2}]")
-            logger.info(f"           Size: {width}x{height} pixels")
-            logger.info(f"           Area: {width * height} pixels")
-        logger.info("=" * 80)
+        # Prepare request - matches FastAPI server format
+        payload = {
+            "image": self._encode_image(image),
+            "boxes": boxes,
+            "threshold": threshold,
+            "mask_threshold": mask_threshold,
+        }
 
-        if not self.load_model():
-            logger.error("Failed to load model")
-            return None
+        # Call API with retry
+        for attempt in range(3):
+            try:
+                response = requests.post(
+                    self.inference_url, json=payload, timeout=self.timeout
+                )
+                response.raise_for_status()
+                result = response.json()
 
-        try:
-            logger.info("STEP 1: Processing inputs...")
+                # Parse response - direct format from server
+                if not result.get("success", False):
+                    logger.error(f"API error: {result.get('error')}")
+                    return None
 
-            # Create labels list - one label per box (all positive)
-            box_labels = [1] * len(boxes)
+                # Decode masks
+                masks = [
+                    torch.from_numpy(self._decode_mask(enc)) for enc in result["masks"]
+                ]
 
-            logger.info(f"  Input boxes: {boxes}")
-            logger.info(f"  Box labels: {box_labels}")
+                if masks:
+                    logger.info(f"✓ Received {len(masks)} masks")
+                    return {
+                        "masks": masks,
+                        "scores": result.get("scores", []),
+                    }
 
-            inputs = self.processor(
-                images=image,
-                input_boxes=[boxes],  # Wrap in list for batch dimension
-                input_boxes_labels=[box_labels],  # One label per box
-                return_tensors="pt",
-            ).to(self.device)
-
-            logger.info(f"  Processor created inputs with keys: {list(inputs.keys())}")
-            if "original_sizes" in inputs:
-                logger.info(f"  Original sizes: {inputs['original_sizes']}")
-            if "pixel_values" in inputs:
-                logger.info(f"  Pixel values shape: {inputs['pixel_values'].shape}")
-            if "input_boxes" in inputs:
-                logger.info(f"  Input boxes shape: {inputs['input_boxes'].shape}")
-
-            logger.info("STEP 2: Running SAM3 inference...")
-
-            with torch.no_grad():
-                outputs = self.model(**inputs)
-
-            logger.info(f"  Model outputs type: {type(outputs)}")
-            if hasattr(outputs, "keys"):
-                logger.info(f"  Output keys: {list(outputs.keys())}")
-
-            logger.info("STEP 3: Post-processing masks...")
-
-            # Post-process to get masks
-            results = self.processor.post_process_instance_segmentation(
-                outputs,
-                threshold=threshold,
-                mask_threshold=mask_threshold,
-                target_sizes=inputs.get("original_sizes").tolist(),
-            )[
-                0
-            ]  # Get first (and only) batch item
-
-            logger.info(f"  Results type: {type(results)}")
-            logger.info(f"  Results keys: {list(results.keys())}")
-
-            # === DETAILED OUTPUT LOGGING ===
-            logger.info("=" * 80)
-            logger.info("OUTPUT DETAILS:")
-
-            if "masks" in results and len(results["masks"]) > 0:
-                masks = results["masks"]
-                logger.info("=" * 80)
-                logger.info(f"✓ Successfully generated {len(masks)} mask(s)")
-                logger.info("=" * 80)
-
-                return results
-            else:
-                logger.warning("=" * 80)
-                logger.warning("✗ No masks generated!")
-                logger.warning("=" * 80)
+                logger.warning("No masks in response")
                 return None
 
-        except Exception as e:
-            logger.error("=" * 80)
-            logger.error(f"✗ Error in box segmentation: {e}", exc_info=True)
-            logger.error("=" * 80)
-            return None
+            except requests.Timeout:
+                logger.error(f"Timeout after {self.timeout}s (attempt {attempt+1}/3)")
+                if attempt < 2:
+                    continue
+
+            except requests.RequestException as e:
+                logger.error(f"Request failed: {e} (attempt {attempt+1}/3)")
+                if attempt < 2:
+                    continue
+
+            except Exception as e:
+                logger.error(f"Unexpected error: {e}", exc_info=True)
+                return None
+
+        logger.error("All retry attempts failed")
+        return None
 
 
 def overlay_masks(image, masks, colors=None, opacity=0.5):
     """
-    Overlay masks on image with different colors
+    Overlay masks on image with colors
 
     Args:
         image: PIL Image
-        masks: torch.Tensor of shape [num_masks, H, W] or list of masks
-        colors: Optional list of RGB tuples (one per mask). If only one color
-                provided, it will be used for all masks.
-        opacity: Float between 0 and 1 for mask transparency
+        masks: torch.Tensor [num_masks, H, W] or list of masks
+        colors: List of RGB tuples or None (auto-generate)
+        opacity: Float 0.0-1.0
 
     Returns:
-        PIL Image with masks overlaid
+        PIL Image with overlaid masks
     """
-    logger.info("=" * 80)
-    logger.info("=== overlay_masks called ===")
-    logger.info(f"  Image size: {image.size}")
-    logger.info(f"  Masks type: {type(masks)}")
-    logger.info(f"  Masks shape: {masks.shape if hasattr(masks, 'shape') else 'N/A'}")
-    logger.info(f"  Opacity: {opacity}")
+    import matplotlib
 
     image = image.convert("RGBA")
 
@@ -235,93 +132,58 @@ def overlay_masks(image, masks, colors=None, opacity=0.5):
     else:
         masks_np = np.array(masks)
 
-    # Ensure masks are in the right shape [num_masks, H, W]
     if len(masks_np.shape) == 2:
-        masks_np = masks_np[np.newaxis, ...]  # Add batch dimension
+        masks_np = masks_np[np.newaxis, ...]
 
     n_masks = masks_np.shape[0]
-    logger.info(f"  Number of masks: {n_masks}")
 
-    # Generate colors if not provided
+    # Generate colors if needed
     if colors is None:
         cmap = matplotlib.colormaps.get_cmap("rainbow").resampled(n_masks)
         colors = [tuple(int(c * 255) for c in cmap(i)[:3]) for i in range(n_masks)]
-        logger.info(f"  Generated {len(colors)} rainbow colors")
-    else:
-        # If only one color provided but multiple masks, repeat it
-        if len(colors) == 1 and n_masks > 1:
-            colors = colors * n_masks
-            logger.info(f"  Repeated single color {n_masks} times: {colors[0]}")
-        logger.info(f"  Using {len(colors)} colors")
-
-    logger.info(f"  Overlaying {n_masks} masks with {len(colors)} colors")
+    elif len(colors) == 1 and n_masks > 1:
+        colors = colors * n_masks
 
     # Apply each mask
-    for i, (mask, color) in enumerate(zip(masks_np, colors)):
-        # Convert to uint8 binary mask
+    for mask, color in zip(masks_np, colors):
         mask_binary = (mask > 0).astype(np.uint8) * 255
-        true_pixels = (mask > 0).sum()
-
-        logger.info(f"  Mask {i}: color={color}, true_pixels={true_pixels}")
-
-        # Create PIL image from mask
         mask_img = Image.fromarray(mask_binary, mode="L")
-
-        # Create colored overlay
         overlay = Image.new("RGBA", image.size, color + (0,))
-
-        # Set alpha channel based on mask with specified opacity
         alpha = mask_img.point(lambda v: int(v * opacity))
         overlay.putalpha(alpha)
-
-        # Composite onto image
         image = Image.alpha_composite(image, overlay)
 
-    logger.info("✓ Overlay complete")
-    logger.info("=" * 80)
     return image
 
 
 def prepare_masks_for_overlay(results):
     """
-    Prepare masks from SAM3 results for overlay
-    Converts torch tensors to a stacked tensor if needed
+    Prepare masks for overlay visualization
 
     Args:
-        results: Dict with 'masks' key containing list of masks,
-                 OR can be a list of masks directly
+        results: Dict with 'masks' key or list of masks
 
     Returns:
-        torch.Tensor of shape [num_masks, H, W]
+        torch.Tensor [num_masks, H, W]
     """
-    # Handle direct list input
     if isinstance(results, list):
         masks = results
     elif isinstance(results, dict) and "masks" in results:
         masks = results["masks"]
     else:
-        logger.warning(f"Unexpected results type: {type(results)}")
         return None
 
     if not masks:
         return None
 
     if isinstance(masks, torch.Tensor):
-        # Already a tensor, ensure 3D shape
-        if len(masks.shape) == 2:
-            return masks.unsqueeze(0)  # Add batch dimension
-        return masks
+        return masks.unsqueeze(0) if len(masks.shape) == 2 else masks
     elif isinstance(masks, list):
-        # Stack list of tensors
         return torch.stack(masks)
     else:
-        # Convert to tensor
         tensor = torch.tensor(masks)
-        if len(tensor.shape) == 2:
-            return tensor.unsqueeze(0)
-        return tensor
+        return tensor.unsqueeze(0) if len(tensor.shape) == 2 else tensor
 
 
-# Global instance - model will load lazily on first use
-sam3_segmenter = SAM3Segmenter()
-logger.info("Global sam3_segmenter instance created (lazy loading enabled)")
+# Global client instance
+sam3_segmenter = SAM3InferenceClient()

--- a/utils/sam3_utils.py
+++ b/utils/sam3_utils.py
@@ -288,15 +288,23 @@ def prepare_masks_for_overlay(results):
     Converts torch tensors to a stacked tensor if needed
 
     Args:
-        results: Dict with 'masks' key containing list of masks
+        results: Dict with 'masks' key containing list of masks,
+                 OR can be a list of masks directly
 
     Returns:
         torch.Tensor of shape [num_masks, H, W]
     """
-    if results is None or "masks" not in results:
+    # Handle direct list input
+    if isinstance(results, list):
+        masks = results
+    elif isinstance(results, dict) and "masks" in results:
+        masks = results["masks"]
+    else:
+        logger.warning(f"Unexpected results type: {type(results)}")
         return None
 
-    masks = results["masks"]
+    if not masks:
+        return None
 
     if isinstance(masks, torch.Tensor):
         # Already a tensor, ensure 3D shape


### PR DESCRIPTION
We plan to use Meta [Sam3](https://ai.meta.com/sam3/) for refining the annotations. 
By clicking `Refine by sam3`, a request is sent to the SAM3 inference server to generate a refined result (editable polygons). You can then use either the refined mask or the original manually annotated mask for training the model.
<img width="3840" height="1988" alt="image" src="https://github.com/user-attachments/assets/ce848244-df74-4e1b-bbaf-3ea4978d0860" />

Todo (optional): Besides a bounding box, we can also use a point or text as a prompt for SAM3 inference.

Companion PR:
https://github.com/mlexchange/mlex_tomo_framework/pull/17