### PR TITLE
Validate class weights on add/remove

### DIFF
--- a/callbacks/control_bar.py
+++ b/callbacks/control_bar.py
@@ -987,12 +987,13 @@ def update_model_parameters(model_name):
         "error",
     ),
     State({"type": "annotation-class-store", "index": ALL}, "data"),
+    Input("annotation-class-container", "children"),
     Input(
         {"type": MATCH, "param_key": "weights", "layer": "input", "name": "weights"},
         "value",
     ),
 )
-def validate_class_weights(all_annotation_classes, weights):
+def validate_class_weights(all_annotation_classes, current_classes, weights):
 
     if weights is None:
         return "Provide a list with a float for each class"
@@ -1003,7 +1004,10 @@ def validate_class_weights(all_annotation_classes, weights):
         # All elements are floats, check if there are the correct number
         # (number of classes)
         if len(parsed_weights) != len(all_annotation_classes):
-            return "This list of floats has the wrong number of entries"
+            return (
+                "Expected "
+                f"{len(all_annotation_classes)} weight values (one per class)."
+            )
         # All good
         return False
     except ValueError:


### PR DESCRIPTION
Several models include a weights parameter to specify per-class weights. This PR updates the class-weights validation callback so it also runs when annotation classes are added or deleted, not only when users edit the weights input. Error feedback now also includes the expected number of weights.

**Expected behavior**
If the selected model parameters include a weights field (class weights), the current setting is validated when:
- a user adds a class
- a user deletes a class
- a user edits the parameter
If any model parameter is in an error state, job submission is blocked (see screenshots below).

<img width="380" height="70" alt="Screenshot 2026-02-17 at 15 15 58" src="https://github.com/user-attachments/assets/3864f9ee-b3ee-4d20-a33b-8c3836e38e2c" />

<img width="508" height="111" alt="Screenshot 2026-02-17 at 15 16 09" src="https://github.com/user-attachments/assets/bc40ca16-4f65-45fa-b0c3-006a68197d36" />


**Notes**
Blocking job submission if a parameter is in error state was in place prior to this PR.
I choose not auto-adjust weights on class add/delete here. I can see arguments both for and against doing so. In principle I think we would like users to set these values intentionally, although I can see how adding a default can improve user experience as well. 
However, I would like to avoid further coupling front-end and model-specific parameters. As is, there is a risk that a future model has a parameter called `weights` with different semantics, which right now, would use the same validation callback. Going forward, figuring out how to provide validation logic with a registered algorithm would be a better path.